### PR TITLE
Update margin property to margin-block in field-editor.svelte

### DIFF
--- a/src/lib/components/contents/details/editor/field-editor.svelte
+++ b/src/lib/components/contents/details/editor/field-editor.svelte
@@ -410,7 +410,7 @@
   }
 
   .comment {
-    margin: 4px;
+    margin-block: 4px;
     line-height: var(--sui-line-height-compact);
   }
 


### PR DESCRIPTION
Very small UI fix, adjusting the margin of comments.

**Before**
![image](https://github.com/sveltia/sveltia-cms/assets/50666443/6581dba6-03fd-4490-b271-13e7267e706c)


**After**
![image](https://github.com/sveltia/sveltia-cms/assets/50666443/8cfd2322-2177-430b-9668-b6586e4c04e7)
