### PR TITLE
allow "directory depth" in repo name

### DIFF
--- a/src/lib/services/config.js
+++ b/src/lib/services/config.js
@@ -105,7 +105,7 @@ const validate = (config) => {
     );
   }
 
-  if (typeof config.backend.repo !== 'string' || config.backend.repo.split('/').length !== 2) {
+  if (typeof config.backend.repo !== 'string') {
     throw new Error(get(_)('config.error.no_repository'));
   }
 


### PR DESCRIPTION
The current check for the repo configuration enforces the github style `username/repo`, but it's not uncommon for self hosted gitlab instances to use multiple levels there (i.e. `team/project/component`)