### PR TITLE
Fix crash when GitLab commit author is null

### DIFF
--- a/src/lib/services/backends/gitlab.js
+++ b/src/lib/services/backends/gitlab.js
@@ -493,7 +493,7 @@ const fetchFileContents = async (fetchingFiles) => {
 
   /**
    * @type {{
-   * author: { id?: string, username?: string },
+   * author: { id?: string, username?: string } | null,
    * authorName: string, authorEmail: string, committedDate: string
    * }[]}
    */
@@ -508,7 +508,7 @@ const fetchFileContents = async (fetchingFiles) => {
       const result = //
         /**
          * @type {{ project: { repository: { [tree_index: string]: { lastCommit: {
-         * author: { id?: string, username?: string },
+         * author: { id?: string, username?: string } | null,
          * authorName: string, authorEmail: string, committedDate: string
          * } } } } } }}
          */ (
@@ -563,13 +563,7 @@ const fetchFileContents = async (fetchingFiles) => {
       };
 
       if (commit) {
-        const {
-          author,
-          authorName,
-          authorEmail,
-          committedDate,
-        } = commit;
-
+        const { author, authorName, authorEmail, committedDate } = commit;
         const { id, username } = author ?? {};
         const idMatcher = id?.match(/\d+/);
 

--- a/src/lib/services/backends/gitlab.js
+++ b/src/lib/services/backends/gitlab.js
@@ -564,12 +564,13 @@ const fetchFileContents = async (fetchingFiles) => {
 
       if (commit) {
         const {
-          author: { id, username },
+          author,
           authorName,
           authorEmail,
           committedDate,
         } = commit;
 
+        const { id, username } = author ?? {};
         const idMatcher = id?.match(/\d+/);
 
         data.meta = {


### PR DESCRIPTION
Fixes #317 
Fixes sveltia/sveltia-cms#319

### Why did this error happen?

It is possible in GitLab to have `author = null` yet have non-null `authorName` and `authorEmail`. This happens when the `authorEmail` does not correspond with the email used for the registration of the GitLab account.

In my case, I registered to GitLab with `example+suffix@mail.com` yet I push all my commits with the email set to `example@mail.com` without the `+suffix` part. GitLab has a problem with linking the `author` to the `authorEmail` and returns `author = null` instead.

The error here happened due to destructuring a null value.

### Fix

Added a fallback for the destructuring.

I initially tried:

```js
const {
  author: { id, username } = {},
  ...
} = commit;
```

but this still resulted in an error. Instead, I applied a safer fallback.

### Testing

I tested this locally, by serving the built sveltia-cms package

```py
python3 -m http.server 8080
```

and replacing the original script in `admin.html`.

```js
<script src="http://localhost:8080/dist/sveltia-cms.js"></script>
```

Now I can log into Sveltia CMS using GitLab OAuth.
