### PR TITLE
Switch to LFS-supporting blob API

### DIFF
--- a/src/lib/services/backends/gitea.js
+++ b/src/lib/services/backends/gitea.js
@@ -492,7 +492,7 @@ const fetchBlob = async (asset) => {
 
   return /** @type {Promise<Blob>} */ (
     fetchAPI(
-      `/repos/${owner}/${repo}/raw/${encodeURIComponent(path)}?ref=${branch}`,
+      `/repos/${owner}/${repo}/media/${encodeURIComponent(path)}?ref=${branch}`,
       {},
       { responseType: 'blob' },
     )


### PR DESCRIPTION
Switch from the raw file API to the media file API (https://gitea.com/api/swagger#/repository/repoGetRawFileOrLFS)  for Gitea backing, which also directly supports retrieving LFS files. This de-facto enables LFS support for Gitea blobs.

There doesn't seem to be a similar endpoint for GitHub API.