### PR TITLE
Fix asset picker empty Field Assets with shared field-level media_folder

### DIFF
--- a/src/lib/components/assets/browser/select-assets-dialog.svelte
+++ b/src/lib/components/assets/browser/select-assets-dialog.svelte
@@ -398,7 +398,8 @@
           {multiple}
           assets={listedAssets.filter(
             (asset) =>
-              equal(asset.folder, selectedFolder) &&
+              asset.folder?.internalPath === selectedFolder.internalPath &&
+              asset.folder?.entryRelative === selectedFolder.entryRelative &&
               (selectedFolder.entryRelative
                 ? getPathInfo(asset.path).dirname === targetFolderPath
                 : true),


### PR DESCRIPTION
## Summary

- Fix Field Assets tab showing "No files found" when multiple collections/singletons define field-level `media_folder` pointing to the same directory
- Root cause: `fast-deep-equal` compares full `AssetFolderInfo` objects, but assets are assigned only the first matching folder
- Fix: Compare by `internalPath` and `entryRelative` instead of deep object equality

## Details

Addresses #606.

The main Assets Page was fixed for shared folder paths in commit 123bf5d3, but `select-assets-dialog.svelte` wasn't updated with an equivalent fix when field-level folders were added in 63606580.

## Test plan

- [x] All existing tests pass (5162 passed, 3 skipped)
- [x] ESLint clean on changed file
- [x] Prettier clean on changed file
- [x] Manual testing: Field Assets shows images when 2+ collections share `media_folder`
- [x] Manual testing: Global Assets unaffected
- [x] Manual testing: Entry Assets for page bundles unaffected