### PR TITLE
WIP: Subdirectory navigation support in asset library

### DIFF
--- a/src/lib/components/assets/assets-page.svelte
+++ b/src/lib/components/assets/assets-page.svelte
@@ -1,7 +1,6 @@
 <script>
   import { _, locale as appLocale } from '@sveltia/i18n';
   import { Alert, Toast } from '@sveltia/ui';
-  import { getPathInfo } from '@sveltia/utils/file';
   import { sleep } from '@sveltia/utils/misc';
   import equal from 'fast-deep-equal';
   import { onMount } from 'svelte';
@@ -25,7 +24,7 @@
     parseLocation,
     updateContentFromHashChange,
   } from '$lib/services/app/navigation';
-  import { allAssets, getAssetSubDirectories, overlaidAsset } from '$lib/services/assets';
+  import { allAssets, getAssetSubDirectories, isInDirectDir, overlaidAsset } from '$lib/services/assets';
   import { assetUpdatesToast } from '$lib/services/assets/data';
   import {
     allAssetFolders,
@@ -50,11 +49,9 @@
   let currentSubPath = $state('');
   let showCreateFolderDialog = $state(false);
 
-  const subDirectories = $derived.by(() => {
-    void $allAssets;
-
-    return getAssetSubDirectories($selectedAssetFolder, currentSubPath);
-  });
+  const subDirectories = $derived.by(() =>
+    getAssetSubDirectories($selectedAssetFolder, currentSubPath),
+  );
 
   const canCreateInFolder = $derived(canCreateAsset($selectedAssetFolder));
 
@@ -79,14 +76,13 @@
   );
 
   const filteredListedAssets = $derived.by(() => {
-    if (!currentSubPath || !$selectedAssetFolder) {
+    const base = $selectedAssetFolder?.internalPath;
+
+    if (!base) {
       return $listedAssets;
     }
 
-    const base = $selectedAssetFolder.internalPath ?? '';
-    const expectedDir = base ? `${base}/${currentSubPath}` : currentSubPath;
-
-    return $listedAssets.filter((asset) => getPathInfo(asset.path).dirname === expectedDir);
+    return $listedAssets.filter((asset) => isInDirectDir(asset.path, base, currentSubPath));
   });
 
   /**
@@ -149,7 +145,7 @@
       $announcedPageStatus = _('viewing_x_asset_folder', {
         values: {
           folder: selectedAssetFolderLabel,
-          count: $listedAssets.length,
+          count: filteredListedAssets.length,
         },
       });
 
@@ -222,6 +218,7 @@
           <AssetList
             {subDirectories}
             {currentSubPath}
+            filteredAssets={filteredListedAssets}
             onNavigateFolder={(subDir) => navigateToSubPath(subDir.path)}
           />
         {/snippet}

--- a/src/lib/components/assets/assets-page.svelte
+++ b/src/lib/components/assets/assets-page.svelte
@@ -1,13 +1,12 @@
 <script>
   import { _, locale as appLocale } from '@sveltia/i18n';
-  import { Alert, Button, Icon, Toast } from '@sveltia/ui';
+  import { Alert, Toast } from '@sveltia/ui';
   import { getPathInfo } from '@sveltia/utils/file';
   import { sleep } from '@sveltia/utils/misc';
   import equal from 'fast-deep-equal';
   import { onMount } from 'svelte';
 
   import AssetDetailsOverlay from '$lib/components/assets/details/asset-details-overlay.svelte';
-  import CreateFolderDialog from '$lib/components/assets/shared/create-folder-dialog.svelte';
   import EditAssetDialog from '$lib/components/assets/details/edit-asset-dialog.svelte';
   import RenameAssetDialog from '$lib/components/assets/details/rename-asset-dialog.svelte';
   import AssetList from '$lib/components/assets/list/asset-list.svelte';
@@ -15,6 +14,8 @@
   import PrimaryToolbar from '$lib/components/assets/list/primary-toolbar.svelte';
   import SecondarySidebar from '$lib/components/assets/list/secondary-sidebar.svelte';
   import SecondaryToolbar from '$lib/components/assets/list/secondary-toolbar.svelte';
+  import Breadcrumb from '$lib/components/assets/shared/breadcrumb.svelte';
+  import CreateFolderDialog from '$lib/components/assets/shared/create-folder-dialog.svelte';
   import PageContainerMainArea from '$lib/components/common/page-container-main-area.svelte';
   import PageContainer from '$lib/components/common/page-container.svelte';
   import SearchMainArea from '$lib/components/search/search-main-area.svelte';
@@ -55,8 +56,6 @@
     return getAssetSubDirectories($selectedAssetFolder, currentSubPath);
   });
 
-  const breadcrumbSegments = $derived(currentSubPath ? ['', ...currentSubPath.split('/')] : ['']);
-
   const canCreateInFolder = $derived(canCreateAsset($selectedAssetFolder));
 
   $effect(() => {
@@ -79,18 +78,6 @@
 
     segments.pop();
     currentSubPath = segments.join('/');
-  };
-
-  /**
-   * Navigate to a specific breadcrumb segment.
-   * @param {number} index Index of the segment to navigate to.
-   */
-  const navigateToSegment = (index) => {
-    if (index === 0) {
-      currentSubPath = '';
-    } else {
-      currentSubPath = breadcrumbSegments.slice(1, index + 1).join('/');
-    }
   };
 
   const selectedAssetFolderLabel = $derived(
@@ -232,38 +219,15 @@
         {/snippet}
         {#snippet mainContent()}
           {#if $selectedAssetFolder}
-            <!-- Breadcrumb -->
-            <div role="navigation" class="breadcrumb" aria-label="Folder navigation">
-              <span class="segments">
-                {#each breadcrumbSegments as segment, index}
-                  {#if index > 0}
-                    <Icon name="chevron_right" />
-                  {/if}
-                  <button
-                    class="crumb"
-                    class:active={index === breadcrumbSegments.length - 1}
-                    onclick={() => navigateToSegment(index)}
-                  >
-                    {index === 0
-                      ? getFolderLabelByCollection($selectedAssetFolder)
-                      : decodeURIComponent(segment)}
-                  </button>
-                {/each}
-              </span>
-              {#if currentSubPath}
-                <Button variant="text" size="small" label={_('go_up')} onclick={navigateUp} />
-              {/if}
-              {#if canCreateInFolder}
-                <Button
-                  variant="text"
-                  size="small"
-                  label={_('assets_dialog.create_folder')}
-                  onclick={() => {
-                    showCreateFolderDialog = true;
-                  }}
-                />
-              {/if}
-            </div>
+            <Breadcrumb
+              bind:currentSubPath
+              rootLabel={getFolderLabelByCollection($selectedAssetFolder)}
+              showUpButton={!!currentSubPath}
+              showCreateButton={canCreateInFolder}
+              onCreateFolder={() => {
+                showCreateFolderDialog = true;
+              }}
+            />
           {/if}
           <AssetList
             {subDirectories}
@@ -323,43 +287,4 @@
 />
 
 <style lang="scss">
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 16px;
-    border-bottom: 1px solid var(--sui-control-border-color);
-
-    .segments {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      flex: auto;
-
-      .crumb {
-        cursor: pointer;
-        border: none;
-        border-radius: 4px;
-        padding: 2px 6px;
-        color: var(--sui-link-color);
-        background: none;
-        font-size: var(--sui-font-size-small);
-        font-family: inherit;
-
-        &:hover {
-          text-decoration: underline;
-        }
-
-        &.active {
-          cursor: default;
-          color: var(--sui-primary-foreground-color);
-          font-weight: var(--sui-font-weight-semi-bold);
-
-          &:hover {
-            text-decoration: none;
-          }
-        }
-      }
-    }
-  }
 </style>

--- a/src/lib/components/assets/assets-page.svelte
+++ b/src/lib/components/assets/assets-page.svelte
@@ -70,16 +70,6 @@
     currentSubPath = subPath ?? '';
   };
 
-  /**
-   * Navigate up one directory level.
-   */
-  const navigateUp = () => {
-    const segments = currentSubPath.split('/');
-
-    segments.pop();
-    currentSubPath = segments.join('/');
-  };
-
   const selectedAssetFolderLabel = $derived(
     // `appLocale.current` is a key, because `getFolderLabelByCollection` can return a localized
     // label
@@ -218,7 +208,7 @@
           {/if}
         {/snippet}
         {#snippet mainContent()}
-          {#if $selectedAssetFolder}
+          {#if $selectedAssetFolder?.internalPath !== undefined}
             <Breadcrumb
               bind:currentSubPath
               rootLabel={getFolderLabelByCollection($selectedAssetFolder)}
@@ -233,7 +223,6 @@
             {subDirectories}
             {currentSubPath}
             onNavigateFolder={(subDir) => navigateToSubPath(subDir.path)}
-            onNavigateUp={currentSubPath ? navigateUp : undefined}
           />
         {/snippet}
         {#snippet secondarySidebar()}

--- a/src/lib/components/assets/assets-page.svelte
+++ b/src/lib/components/assets/assets-page.svelte
@@ -26,7 +26,11 @@
   } from '$lib/services/app/navigation';
   import { allAssets, getAssetSubDirectories, overlaidAsset } from '$lib/services/assets';
   import { assetUpdatesToast } from '$lib/services/assets/data';
-  import { allAssetFolders, canCreateAsset, selectedAssetFolder } from '$lib/services/assets/folders';
+  import {
+    allAssetFolders,
+    canCreateAsset,
+    selectedAssetFolder,
+  } from '$lib/services/assets/folders';
   import {
     currentAssetSubPath,
     getFolderLabelByCollection,
@@ -51,9 +55,7 @@
     return getAssetSubDirectories($selectedAssetFolder, currentSubPath);
   });
 
-  const breadcrumbSegments = $derived(
-    currentSubPath ? ['', ...currentSubPath.split('/')] : [''],
-  );
+  const breadcrumbSegments = $derived(currentSubPath ? ['', ...currentSubPath.split('/')] : ['']);
 
   const canCreateInFolder = $derived(canCreateAsset($selectedAssetFolder));
 
@@ -249,19 +251,16 @@
                 {/each}
               </span>
               {#if currentSubPath}
-                <Button
-                  variant="text"
-                  size="small"
-                  label={_('go_up')}
-                  onclick={navigateUp}
-                />
+                <Button variant="text" size="small" label={_('go_up')} onclick={navigateUp} />
               {/if}
               {#if canCreateInFolder}
                 <Button
                   variant="text"
                   size="small"
                   label={_('assets_dialog.create_folder')}
-                  onclick={() => { showCreateFolderDialog = true; }}
+                  onclick={() => {
+                    showCreateFolderDialog = true;
+                  }}
                 />
               {/if}
             </div>
@@ -317,7 +316,7 @@
 <CreateFolderDialog
   open={showCreateFolderDialog}
   parentFolder={$selectedAssetFolder}
-  currentSubPath={currentSubPath}
+  {currentSubPath}
   onClose={() => {
     showCreateFolderDialog = false;
   }}
@@ -361,6 +360,6 @@
           }
         }
       }
+    }
   }
-}
 </style>

--- a/src/lib/components/assets/assets-page.svelte
+++ b/src/lib/components/assets/assets-page.svelte
@@ -285,6 +285,3 @@
     showCreateFolderDialog = false;
   }}
 />
-
-<style lang="scss">
-</style>

--- a/src/lib/components/assets/assets-page.svelte
+++ b/src/lib/components/assets/assets-page.svelte
@@ -24,7 +24,12 @@
     parseLocation,
     updateContentFromHashChange,
   } from '$lib/services/app/navigation';
-  import { allAssets, getAssetSubDirectories, isInDirectDir, overlaidAsset } from '$lib/services/assets';
+  import {
+    allAssets,
+    getAssetSubDirectories,
+    isInDirectDir,
+    overlaidAsset,
+  } from '$lib/services/assets';
   import { assetUpdatesToast } from '$lib/services/assets/data';
   import {
     allAssetFolders,

--- a/src/lib/components/assets/assets-page.svelte
+++ b/src/lib/components/assets/assets-page.svelte
@@ -1,11 +1,13 @@
 <script>
   import { _, locale as appLocale } from '@sveltia/i18n';
-  import { Alert, Toast } from '@sveltia/ui';
+  import { Alert, Button, Icon, Toast } from '@sveltia/ui';
+  import { getPathInfo } from '@sveltia/utils/file';
   import { sleep } from '@sveltia/utils/misc';
   import equal from 'fast-deep-equal';
   import { onMount } from 'svelte';
 
   import AssetDetailsOverlay from '$lib/components/assets/details/asset-details-overlay.svelte';
+  import CreateFolderDialog from '$lib/components/assets/shared/create-folder-dialog.svelte';
   import EditAssetDialog from '$lib/components/assets/details/edit-asset-dialog.svelte';
   import RenameAssetDialog from '$lib/components/assets/details/rename-asset-dialog.svelte';
   import AssetList from '$lib/components/assets/list/asset-list.svelte';
@@ -22,10 +24,11 @@
     parseLocation,
     updateContentFromHashChange,
   } from '$lib/services/app/navigation';
-  import { allAssets, overlaidAsset } from '$lib/services/assets';
+  import { allAssets, getAssetSubDirectories, overlaidAsset } from '$lib/services/assets';
   import { assetUpdatesToast } from '$lib/services/assets/data';
-  import { allAssetFolders, selectedAssetFolder } from '$lib/services/assets/folders';
+  import { allAssetFolders, canCreateAsset, selectedAssetFolder } from '$lib/services/assets/folders';
   import {
+    currentAssetSubPath,
     getFolderLabelByCollection,
     listedAssets,
     showAssetOverlay,
@@ -38,6 +41,56 @@
   let isIndexPage = $state(false);
   let isSearchPage = $state(false);
 
+  /** @type {string} */
+  let currentSubPath = $state('');
+  let showCreateFolderDialog = $state(false);
+
+  const subDirectories = $derived.by(() => {
+    void $allAssets;
+
+    return getAssetSubDirectories($selectedAssetFolder, currentSubPath);
+  });
+
+  const breadcrumbSegments = $derived(
+    currentSubPath ? ['', ...currentSubPath.split('/')] : [''],
+  );
+
+  const canCreateInFolder = $derived(canCreateAsset($selectedAssetFolder));
+
+  $effect(() => {
+    $currentAssetSubPath = currentSubPath;
+  });
+
+  /**
+   * Navigate to a subfolder path.
+   * @param {string} subPath Subfolder path relative to folder root.
+   */
+  const navigateToSubPath = (subPath) => {
+    currentSubPath = subPath ?? '';
+  };
+
+  /**
+   * Navigate up one directory level.
+   */
+  const navigateUp = () => {
+    const segments = currentSubPath.split('/');
+
+    segments.pop();
+    currentSubPath = segments.join('/');
+  };
+
+  /**
+   * Navigate to a specific breadcrumb segment.
+   * @param {number} index Index of the segment to navigate to.
+   */
+  const navigateToSegment = (index) => {
+    if (index === 0) {
+      currentSubPath = '';
+    } else {
+      currentSubPath = breadcrumbSegments.slice(1, index + 1).join('/');
+    }
+  };
+
   const selectedAssetFolderLabel = $derived(
     // `appLocale.current` is a key, because `getFolderLabelByCollection` can return a localized
     // label
@@ -45,6 +98,17 @@
       ? getFolderLabelByCollection($selectedAssetFolder)
       : '',
   );
+
+  const filteredListedAssets = $derived.by(() => {
+    if (!currentSubPath || !$selectedAssetFolder) {
+      return $listedAssets;
+    }
+
+    const base = $selectedAssetFolder.internalPath ?? '';
+    const expectedDir = base ? `${base}/${currentSubPath}` : currentSubPath;
+
+    return $listedAssets.filter((asset) => getPathInfo(asset.path).dirname === expectedDir);
+  });
 
   /**
    * Navigate to the asset list or asset details page given the URL hash.
@@ -95,6 +159,7 @@
       $selectedAssetFolder = undefined;
     } else if (!equal($selectedAssetFolder, folder)) {
       $selectedAssetFolder = folder;
+      currentSubPath = '';
     }
 
     if (!fileName) {
@@ -139,7 +204,12 @@
 <PageContainer aria-label={_('asset_library')}>
   {#snippet primarySidebar()}
     {#if !$isSmallScreen || isIndexPage}
-      <PrimarySidebar {isSearchPage} />
+      <PrimarySidebar
+        {isSearchPage}
+        onSelect={() => {
+          currentSubPath = '';
+        }}
+      />
     {/if}
   {/snippet}
   {#snippet main()}
@@ -154,12 +224,54 @@
           <PrimaryToolbar />
         {/snippet}
         {#snippet secondaryToolbar()}
-          {#if $listedAssets.length}
-            <SecondaryToolbar />
+          {#if filteredListedAssets.length}
+            <SecondaryToolbar filteredAssets={filteredListedAssets} />
           {/if}
         {/snippet}
         {#snippet mainContent()}
-          <AssetList />
+          {#if $selectedAssetFolder}
+            <!-- Breadcrumb -->
+            <div role="navigation" class="breadcrumb" aria-label="Folder navigation">
+              <span class="segments">
+                {#each breadcrumbSegments as segment, index}
+                  {#if index > 0}
+                    <Icon name="chevron_right" />
+                  {/if}
+                  <button
+                    class="crumb"
+                    class:active={index === breadcrumbSegments.length - 1}
+                    onclick={() => navigateToSegment(index)}
+                  >
+                    {index === 0
+                      ? getFolderLabelByCollection($selectedAssetFolder)
+                      : decodeURIComponent(segment)}
+                  </button>
+                {/each}
+              </span>
+              {#if currentSubPath}
+                <Button
+                  variant="text"
+                  size="small"
+                  label={_('go_up')}
+                  onclick={navigateUp}
+                />
+              {/if}
+              {#if canCreateInFolder}
+                <Button
+                  variant="text"
+                  size="small"
+                  label={_('assets_dialog.create_folder')}
+                  onclick={() => { showCreateFolderDialog = true; }}
+                />
+              {/if}
+            </div>
+          {/if}
+          <AssetList
+            {subDirectories}
+            {currentSubPath}
+            onNavigateFolder={(subDir) => navigateToSubPath(subDir.path)}
+            onNavigateUp={currentSubPath ? navigateUp : undefined}
+          />
         {/snippet}
         {#snippet secondarySidebar()}
           <SecondarySidebar />
@@ -201,3 +313,54 @@
     {_('assets_deleted', { values: { count: $assetUpdatesToast.count } })}
   </Alert>
 </Toast>
+
+<CreateFolderDialog
+  open={showCreateFolderDialog}
+  parentFolder={$selectedAssetFolder}
+  currentSubPath={currentSubPath}
+  onClose={() => {
+    showCreateFolderDialog = false;
+  }}
+/>
+
+<style lang="scss">
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-bottom: 1px solid var(--sui-control-border-color);
+
+    .segments {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      flex: auto;
+
+      .crumb {
+        cursor: pointer;
+        border: none;
+        border-radius: 4px;
+        padding: 2px 6px;
+        color: var(--sui-link-color);
+        background: none;
+        font-size: var(--sui-font-size-small);
+        font-family: inherit;
+
+        &:hover {
+          text-decoration: underline;
+        }
+
+        &.active {
+          cursor: default;
+          color: var(--sui-primary-foreground-color);
+          font-weight: var(--sui-font-weight-semi-bold);
+
+          &:hover {
+            text-decoration: none;
+          }
+        }
+      }
+  }
+}
+</style>

--- a/src/lib/components/assets/browser/assets-panel.svelte
+++ b/src/lib/components/assets/browser/assets-panel.svelte
@@ -96,7 +96,7 @@
   };
 </script>
 
-{#if showSubDirs && (subDirectories.length || !isRootLevel) || filteredAssets.length}
+{#if (showSubDirs && (subDirectories.length || !isRootLevel)) || filteredAssets.length}
   <div role="none" class="grid-wrapper">
     <SimpleImageGrid {multiple} {gridId} {viewType} showTitle={true}>
       {#if showSubDirs}
@@ -115,9 +115,11 @@
           </SimpleImageGridItem>
         {/if}
         {#each subDirectories as subDir (subDir.path)}
-          {@const sel = chooseFolders && isSelected(
-            /** @type {any} */ ({ name: subDir.name, path: subDir.path, kind: 'other' }),
-          )}
+          {@const sel =
+            chooseFolders &&
+            isSelected(
+              /** @type {any} */ ({ name: subDir.name, path: subDir.path, kind: 'other' }),
+            )}
           <SimpleImageGridItem
             value={subDir.path}
             {viewType}

--- a/src/lib/components/assets/browser/assets-panel.svelte
+++ b/src/lib/components/assets/browser/assets-panel.svelte
@@ -39,8 +39,6 @@
    * @property {(subDir: SubDirectory) => void} [onNavigateFolder] Called when a subdirectory is
    * clicked.
    * @property {boolean} [chooseFolders] Whether to only allow selecting folders.
-   * @property {() => void} [onNavigateUp] Called when the "go up" button is clicked.
-   * @property {string} [currentSubPath] Current sub-path within the folder.
    */
 
   /** @type {Props} */
@@ -58,11 +56,9 @@
     subDirectories = [],
     onNavigateFolder = undefined,
     chooseFolders = false,
-    currentSubPath = '',
     /* eslint-enable prefer-const */
   } = $props();
 
-  const isRootLevel = $derived(!currentSubPath);
   const showSubDirs = $derived(!searchTerms || chooseFolders);
 
   const filteredAssets = $derived(
@@ -96,7 +92,7 @@
   };
 </script>
 
-{#if (showSubDirs && (subDirectories.length || !isRootLevel)) || filteredAssets.length}
+{#if (showSubDirs && subDirectories.length) || filteredAssets.length}
   <div role="none" class="grid-wrapper">
     <SimpleImageGrid {multiple} {gridId} {viewType} showTitle={true}>
       {#if showSubDirs}

--- a/src/lib/components/assets/browser/assets-panel.svelte
+++ b/src/lib/components/assets/browser/assets-panel.svelte
@@ -1,6 +1,6 @@
 <script>
   import { _ } from '@sveltia/i18n';
-  import { EmptyState, InfiniteScroll } from '@sveltia/ui';
+  import { EmptyState, Icon, InfiniteScroll } from '@sveltia/ui';
   import { sleep } from '@sveltia/utils/misc';
   import { stripSlashes } from '@sveltia/utils/string';
   import equal from 'fast-deep-equal';
@@ -17,6 +17,12 @@
    */
 
   /**
+   * @typedef {object} SubDirectory
+   * @property {string} name Subdirectory name.
+   * @property {string} path Subdirectory path relative to the base folder.
+   */
+
+  /**
    * @typedef {object} Props
    * @property {boolean} [multiple] Whether to allow selecting multiple assets.
    * @property {Asset[]} [assets] Asset list.
@@ -28,6 +34,12 @@
    * transparent image.
    * @property {SelectedResource[]} [selectedResources] Selected resources.
    * @property {(detail: { asset: Asset }) => void} [onSelect] Custom `select` event handler.
+   * @property {SubDirectory[]} [subDirectories] Subdirectories of the current folder.
+   * @property {(subDir: SubDirectory) => void} [onNavigateFolder] Called when a subdirectory is
+   * clicked.
+   * @property {boolean} [chooseFolders] Whether to only allow selecting folders.
+   * @property {() => void} [onNavigateUp] Called when the "go up" button is clicked.
+   * @property {string} [currentSubPath] Current sub-path within the folder.
    */
 
   /** @type {Props} */
@@ -42,8 +54,16 @@
     checkerboard = false,
     selectedResources = $bindable([]),
     onSelect = undefined,
+    subDirectories = [],
+    onNavigateFolder = undefined,
+    chooseFolders = false,
+    onNavigateUp = undefined,
+    currentSubPath = '',
     /* eslint-enable prefer-const */
   } = $props();
+
+  const isRootLevel = $derived(!currentSubPath);
+  const showSubDirs = $derived(!searchTerms || chooseFolders);
 
   const filteredAssets = $derived(
     (searchTerms ? assets.filter(({ name }) => normalize(name).includes(searchTerms)) : assets)
@@ -76,40 +96,84 @@
   };
 </script>
 
-{#if filteredAssets.length}
+{#if showSubDirs && (subDirectories.length || !isRootLevel) || filteredAssets.length}
   <div role="none" class="grid-wrapper">
     <SimpleImageGrid {multiple} {gridId} {viewType} showTitle={true}>
-      <InfiniteScroll items={filteredAssets} itemKey="path">
-        {#snippet renderItem(/** @type {Asset} */ asset)}
-          {#await sleep() then}
-            {@const { kind, name, path, unsaved, folder } = asset}
-            <!-- Show asset path relative to the base folder, or just file name -->
-            {@const relPath =
-              basePath && !folder.entryRelative ? stripSlashes(path.replace(basePath, '')) : name}
-            <SimpleImageGridItem
-              value={path}
-              {viewType}
-              {multiple}
-              selected={isSelected(asset)}
-              onChange={({ detail: { selected } }) => {
-                onSelectionChange(asset, selected);
-              }}
-            >
-              {#if viewType === 'grid' && unsaved}
-                <div role="none" class="unsaved">{_('assets_dialog.unsaved')}</div>
-              {/if}
-              <AssetPreview {kind} {asset} alt={relPath} variant="tile" {checkerboard} />
-              {#if !$isSmallScreen || viewType === 'list'}
-                <AssetPath path={relPath}>
-                  {#if viewType === 'list' && unsaved}
-                    <div role="none" class="unsaved">{_('assets_dialog.unsaved')}</div>
-                  {/if}
-                </AssetPath>
-              {/if}
-            </SimpleImageGridItem>
-          {/await}
-        {/snippet}
-      </InfiniteScroll>
+      {#if showSubDirs}
+        {#if !isRootLevel && onNavigateUp}
+          <SimpleImageGridItem
+            value=".."
+            {viewType}
+            {multiple}
+            selected={false}
+            onChange={() => onNavigateUp()}
+          >
+            <span role="none" class="dir-preview {viewType}">
+              <Icon name="arrow_upward" />
+            </span>
+            <AssetPath path=".." />
+          </SimpleImageGridItem>
+        {/if}
+        {#each subDirectories as subDir (subDir.path)}
+          {@const sel = chooseFolders && isSelected(
+            /** @type {any} */ ({ name: subDir.name, path: subDir.path, kind: 'other' }),
+          )}
+          <SimpleImageGridItem
+            value={subDir.path}
+            {viewType}
+            {multiple}
+            {gridId}
+            selected={sel}
+            onChange={({ detail: { selected } }) => {
+              if (chooseFolders) {
+                onSelectionChange(
+                  /** @type {any} */ ({ name: subDir.name, path: subDir.path, kind: 'other' }),
+                  selected,
+                );
+              } else {
+                onNavigateFolder?.(subDir);
+              }
+            }}
+          >
+            <span role="none" class="dir-preview {viewType}">
+              <Icon name="folder" />
+            </span>
+            <AssetPath path={subDir.name} />
+          </SimpleImageGridItem>
+        {/each}
+      {/if}
+      {#if !chooseFolders && filteredAssets.length}
+        <InfiniteScroll items={filteredAssets} itemKey="path">
+          {#snippet renderItem(/** @type {Asset} */ asset)}
+            {#await sleep() then}
+              {@const { kind, name, path, unsaved, folder } = asset}
+              {@const relPath =
+                basePath && !folder.entryRelative ? stripSlashes(path.replace(basePath, '')) : name}
+              <SimpleImageGridItem
+                value={path}
+                {viewType}
+                {multiple}
+                selected={isSelected(asset)}
+                onChange={({ detail: { selected } }) => {
+                  onSelectionChange(asset, selected);
+                }}
+              >
+                {#if viewType === 'grid' && unsaved}
+                  <div role="none" class="unsaved">{_('assets_dialog.unsaved')}</div>
+                {/if}
+                <AssetPreview {kind} {asset} alt={relPath} variant="tile" {checkerboard} />
+                {#if !$isSmallScreen || viewType === 'list'}
+                  <AssetPath path={relPath}>
+                    {#if viewType === 'list' && unsaved}
+                      <div role="none" class="unsaved">{_('assets_dialog.unsaved')}</div>
+                    {/if}
+                  </AssetPath>
+                {/if}
+              </SimpleImageGridItem>
+            {/await}
+          {/snippet}
+        </InfiniteScroll>
+      {/if}
     </SimpleImageGrid>
   </div>
 {:else}
@@ -158,5 +222,33 @@
     color: var(--sui-info-foreground-color);
     background-color: var(--sui-info-background-color);
     font-size: var(--sui-font-size-small);
+  }
+
+  .dir-preview {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    aspect-ratio: 1 / 1;
+    border: 1px solid var(--sui-control-border-color);
+    border-radius: var(--sui-control-medium-border-radius);
+    background-color: var(--sui-secondary-background-color);
+    width: 100%;
+
+    :global(.icon) {
+      font-size: 48px;
+      color: var(--sui-secondary-foreground-color);
+      opacity: 0.6;
+    }
+
+    &.list {
+      width: 64px;
+      aspect-ratio: unset;
+      height: 64px;
+      flex: none;
+
+      :global(.icon) {
+        font-size: 24px;
+      }
+    }
   }
 </style>

--- a/src/lib/components/assets/browser/assets-panel.svelte
+++ b/src/lib/components/assets/browser/assets-panel.svelte
@@ -14,13 +14,7 @@
   import { isSmallScreen } from '$lib/services/user/env';
 
   /**
-   * @import { Asset, SelectedResource, ViewType } from '$lib/types/private';
-   */
-
-  /**
-   * @typedef {object} SubDirectory
-   * @property {string} name Subdirectory name.
-   * @property {string} path Subdirectory path relative to the base folder.
+   * @import { Asset, SelectedResource, SubDirectory, ViewType } from '$lib/types/private';
    */
 
   /**

--- a/src/lib/components/assets/browser/assets-panel.svelte
+++ b/src/lib/components/assets/browser/assets-panel.svelte
@@ -1,6 +1,6 @@
 <script>
   import { _ } from '@sveltia/i18n';
-  import { EmptyState, Icon, InfiniteScroll } from '@sveltia/ui';
+  import { EmptyState, InfiniteScroll } from '@sveltia/ui';
   import { sleep } from '@sveltia/utils/misc';
   import { stripSlashes } from '@sveltia/utils/string';
   import equal from 'fast-deep-equal';
@@ -9,6 +9,7 @@
   import SimpleImageGridItem from '$lib/components/assets/browser/simple-image-grid-item.svelte';
   import SimpleImageGrid from '$lib/components/assets/browser/simple-image-grid.svelte';
   import AssetPreview from '$lib/components/assets/shared/asset-preview.svelte';
+  import FolderPreview from '$lib/components/assets/shared/folder-preview.svelte';
   import { normalize } from '$lib/services/search/util';
   import { isSmallScreen } from '$lib/services/user/env';
 
@@ -57,7 +58,6 @@
     subDirectories = [],
     onNavigateFolder = undefined,
     chooseFolders = false,
-    onNavigateUp = undefined,
     currentSubPath = '',
     /* eslint-enable prefer-const */
   } = $props();
@@ -100,20 +100,6 @@
   <div role="none" class="grid-wrapper">
     <SimpleImageGrid {multiple} {gridId} {viewType} showTitle={true}>
       {#if showSubDirs}
-        {#if !isRootLevel && onNavigateUp}
-          <SimpleImageGridItem
-            value=".."
-            {viewType}
-            {multiple}
-            selected={false}
-            onChange={() => onNavigateUp()}
-          >
-            <span role="none" class="dir-preview {viewType}">
-              <Icon name="arrow_upward" />
-            </span>
-            <AssetPath path=".." />
-          </SimpleImageGridItem>
-        {/if}
         {#each subDirectories as subDir (subDir.path)}
           {@const sel =
             chooseFolders &&
@@ -124,7 +110,6 @@
             value={subDir.path}
             {viewType}
             {multiple}
-            {gridId}
             selected={sel}
             onChange={({ detail: { selected } }) => {
               if (chooseFolders) {
@@ -137,8 +122,8 @@
               }
             }}
           >
-            <span role="none" class="dir-preview {viewType}">
-              <Icon name="folder" />
+            <span class="preview">
+              <FolderPreview {viewType} />
             </span>
             <AssetPath path={subDir.name} />
           </SimpleImageGridItem>
@@ -224,33 +209,5 @@
     color: var(--sui-info-foreground-color);
     background-color: var(--sui-info-background-color);
     font-size: var(--sui-font-size-small);
-  }
-
-  .dir-preview {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    aspect-ratio: 1 / 1;
-    border: 1px solid var(--sui-control-border-color);
-    border-radius: var(--sui-control-medium-border-radius);
-    background-color: var(--sui-secondary-background-color);
-    width: 100%;
-
-    :global(.icon) {
-      font-size: 48px;
-      color: var(--sui-secondary-foreground-color);
-      opacity: 0.6;
-    }
-
-    &.list {
-      width: 64px;
-      aspect-ratio: unset;
-      height: 64px;
-      flex: none;
-
-      :global(.icon) {
-        font-size: 24px;
-      }
-    }
   }
 </style>

--- a/src/lib/components/assets/browser/assets-panel.svelte
+++ b/src/lib/components/assets/browser/assets-panel.svelte
@@ -24,6 +24,7 @@
    * @property {ViewType} [viewType] View type.
    * @property {string} [searchTerms] Search terms for filtering assets.
    * @property {string} [basePath] Path to an asset folder, if any folder is selected.
+   * @property {string} [publicBasePath] Public URL path to an asset folder.
    * @property {string} [gridId] The `id` attribute of the inner listbox.
    * @property {boolean} [checkerboard] Whether to show a checkerboard background below a
    * transparent image.
@@ -43,6 +44,7 @@
     viewType = 'grid',
     searchTerms = '',
     basePath = undefined,
+    publicBasePath = undefined,
     gridId = undefined,
     checkerboard = false,
     selectedResources = $bindable([]),
@@ -91,10 +93,11 @@
     <SimpleImageGrid {multiple} {gridId} {viewType} showTitle={true}>
       {#if showSubDirs}
         {#each subDirectories as subDir (subDir.path)}
+          {@const fullPath = publicBasePath ? `${publicBasePath}/${subDir.path}` : subDir.path}
           {@const sel =
             chooseFolders &&
             isSelected(
-              /** @type {any} */ ({ name: subDir.name, path: subDir.path, kind: 'other' }),
+              /** @type {any} */ ({ name: subDir.name, path: fullPath, kind: 'other' }),
             )}
           <SimpleImageGridItem
             value={subDir.path}
@@ -104,12 +107,15 @@
             onChange={({ detail: { selected } }) => {
               if (chooseFolders) {
                 onSelectionChange(
-                  /** @type {any} */ ({ name: subDir.name, path: subDir.path, kind: 'other' }),
+                  /** @type {any} */ ({ name: subDir.name, path: fullPath, kind: 'other' }),
                   selected,
                 );
               } else {
                 onNavigateFolder?.(subDir);
               }
+            }}
+            ondblclick={() => {
+              onNavigateFolder?.(subDir);
             }}
           >
             <span class="preview">

--- a/src/lib/components/assets/browser/internal-assets-panel.svelte
+++ b/src/lib/components/assets/browser/internal-assets-panel.svelte
@@ -7,7 +7,12 @@
 
   /**
    * @import { Asset, SelectedResource } from '$lib/types/private';
-   * @import { SubDirectory } from './assets-panel.svelte';
+   */
+
+  /**
+   * @typedef {object} SubDirectory
+   * @property {string} name Subdirectory name.
+   * @property {string} path Subdirectory path relative to the base folder.
    */
 
   /**
@@ -23,8 +28,6 @@
    * @property {(subDir: SubDirectory) => void} [onNavigateFolder] Called when a subdirectory is
    * clicked.
    * @property {boolean} [chooseFolders] Whether to only allow selecting folders.
-   * @property {() => void} [onNavigateUp] Called when the "go up" button is clicked.
-   * @property {string} [currentSubPath] Current sub-path within the folder.
    */
 
   /** @type {Props} */
@@ -40,8 +43,6 @@
     subDirectories = [],
     onNavigateFolder = undefined,
     chooseFolders = false,
-    onNavigateUp = undefined,
-    currentSubPath = '',
     /* eslint-enable prefer-const */
   } = $props();
 
@@ -70,7 +71,5 @@
     {subDirectories}
     {onNavigateFolder}
     {chooseFolders}
-    {onNavigateUp}
-    {currentSubPath}
   />
 </DropZone>

--- a/src/lib/components/assets/browser/internal-assets-panel.svelte
+++ b/src/lib/components/assets/browser/internal-assets-panel.svelte
@@ -16,6 +16,7 @@
    * @property {Asset[]} [assets] Asset list.
    * @property {string} [searchTerms] Search terms for filtering assets.
    * @property {string} [basePath] Path to an asset folder, if any folder is selected.
+   * @property {string} [publicBasePath] Public URL path to an asset folder.
    * @property {SelectedResource[]} selectedResources Selected resources.
    * @property {(detail: { files: File[] }) => void} [onDrop] Custom `Drop` event handler.
    * @property {SubDirectory[]} [subDirectories] Subdirectories of the current folder.
@@ -32,6 +33,7 @@
     assets = [],
     searchTerms = '',
     basePath = undefined,
+    publicBasePath = undefined,
     selectedResources = $bindable([]),
     onDrop,
     subDirectories = [],
@@ -59,6 +61,7 @@
     viewType={$selectAssetsView?.type}
     {searchTerms}
     {basePath}
+    {publicBasePath}
     gridId="select-assets-grid"
     checkerboard={true}
     bind:selectedResources

--- a/src/lib/components/assets/browser/internal-assets-panel.svelte
+++ b/src/lib/components/assets/browser/internal-assets-panel.svelte
@@ -6,13 +6,7 @@
   import { selectAssetsView } from '$lib/services/contents/editor';
 
   /**
-   * @import { Asset, SelectedResource } from '$lib/types/private';
-   */
-
-  /**
-   * @typedef {object} SubDirectory
-   * @property {string} name Subdirectory name.
-   * @property {string} path Subdirectory path relative to the base folder.
+   * @import { Asset, SelectedResource, SubDirectory } from '$lib/types/private';
    */
 
   /**

--- a/src/lib/components/assets/browser/internal-assets-panel.svelte
+++ b/src/lib/components/assets/browser/internal-assets-panel.svelte
@@ -7,6 +7,7 @@
 
   /**
    * @import { Asset, SelectedResource } from '$lib/types/private';
+   * @import { SubDirectory } from './assets-panel.svelte';
    */
 
   /**
@@ -18,6 +19,12 @@
    * @property {string} [basePath] Path to an asset folder, if any folder is selected.
    * @property {SelectedResource[]} selectedResources Selected resources.
    * @property {(detail: { files: File[] }) => void} [onDrop] Custom `Drop` event handler.
+   * @property {SubDirectory[]} [subDirectories] Subdirectories of the current folder.
+   * @property {(subDir: SubDirectory) => void} [onNavigateFolder] Called when a subdirectory is
+   * clicked.
+   * @property {boolean} [chooseFolders] Whether to only allow selecting folders.
+   * @property {() => void} [onNavigateUp] Called when the "go up" button is clicked.
+   * @property {string} [currentSubPath] Current sub-path within the folder.
    */
 
   /** @type {Props} */
@@ -30,6 +37,11 @@
     basePath = undefined,
     selectedResources = $bindable([]),
     onDrop,
+    subDirectories = [],
+    onNavigateFolder = undefined,
+    chooseFolders = false,
+    onNavigateUp = undefined,
+    currentSubPath = '',
     /* eslint-enable prefer-const */
   } = $props();
 
@@ -55,5 +67,10 @@
     gridId="select-assets-grid"
     checkerboard={true}
     bind:selectedResources
+    {subDirectories}
+    {onNavigateFolder}
+    {chooseFolders}
+    {onNavigateUp}
+    {currentSubPath}
   />
 </DropZone>

--- a/src/lib/components/assets/browser/select-assets-dialog.svelte
+++ b/src/lib/components/assets/browser/select-assets-dialog.svelte
@@ -17,11 +17,11 @@
   import { getPathInfo } from '@sveltia/utils/file';
   import equal from 'fast-deep-equal';
 
-  import Breadcrumb from '$lib/components/assets/shared/breadcrumb.svelte';
   import CloudinaryPanel from '$lib/components/assets/browser/cloudinary-panel.svelte';
-  import CreateFolderDialog from '$lib/components/assets/shared/create-folder-dialog.svelte';
   import ExternalAssetsPanel from '$lib/components/assets/browser/external-assets-panel.svelte';
   import InternalAssetsPanel from '$lib/components/assets/browser/internal-assets-panel.svelte';
+  import Breadcrumb from '$lib/components/assets/shared/breadcrumb.svelte';
+  import CreateFolderDialog from '$lib/components/assets/shared/create-folder-dialog.svelte';
   import ViewSwitcher from '$lib/components/common/page-toolbar/view-switcher.svelte';
   import { allAssets, getAssetSubDirectories } from '$lib/services/assets';
   import { canCreateAsset } from '$lib/services/assets/folders';
@@ -167,7 +167,6 @@
 
     if (originalEntry) {
       const entryDir = getPathInfo(Object.values(originalEntry.locales)[0].path).dirname;
-
       const baseDir = subPath ? `${entryDir}/${subPath}` : entryDir;
 
       return currentSubPath ? `${baseDir}/${currentSubPath}` : baseDir;
@@ -194,17 +193,6 @@
    */
   const navigateToSubPath = (subPath) => {
     currentSubPath = subPath ?? '';
-    selectedResources = [];
-  };
-
-  /**
-   * Navigate up one directory level.
-   */
-  const navigateUp = () => {
-    const segments = currentSubPath.split('/');
-
-    segments.pop();
-    currentSubPath = segments.join('/');
     selectedResources = [];
   };
 
@@ -287,7 +275,7 @@
         return getPathInfo(asset.path).dirname === expectedDir;
       }
 
-      // At root level of the folder, only include files directly in the root (not in subdirs)
+      // At root level, only include files in the root (not in subdirectories)
       return getPathInfo(asset.path).dirname === selectedFolder.internalPath;
     }
 
@@ -571,8 +559,6 @@
               {subDirectories}
               onNavigateFolder={(subDir) => navigateToSubPath(subDir.path)}
               chooseFolders={forFolder}
-              onNavigateUp={currentSubPath ? navigateUp : undefined}
-              {currentSubPath}
               onDrop={({ files }) => {
                 onDrop(files);
               }}

--- a/src/lib/components/assets/browser/select-assets-dialog.svelte
+++ b/src/lib/components/assets/browser/select-assets-dialog.svelte
@@ -546,6 +546,7 @@
               bind:selectedResources
               {searchTerms}
               basePath={selectedFolder.internalPath}
+              publicBasePath={selectedFolder.publicPath}
               {subDirectories}
               onNavigateFolder={(subDir) => navigateToSubPath(subDir.path)}
               chooseFolders={forFolder}

--- a/src/lib/components/assets/browser/select-assets-dialog.svelte
+++ b/src/lib/components/assets/browser/select-assets-dialog.svelte
@@ -23,7 +23,7 @@
   import Breadcrumb from '$lib/components/assets/shared/breadcrumb.svelte';
   import CreateFolderDialog from '$lib/components/assets/shared/create-folder-dialog.svelte';
   import ViewSwitcher from '$lib/components/common/page-toolbar/view-switcher.svelte';
-  import { allAssets, getAssetSubDirectories } from '$lib/services/assets';
+  import { allAssets, getAssetSubDirectories, isInDirectDir } from '$lib/services/assets';
   import { canCreateAsset } from '$lib/services/assets/folders';
   import { selectAssetsView, showContentOverlay } from '$lib/services/contents/editor';
   import {
@@ -175,11 +175,9 @@
     // Append a placeholder because the complete path is not determined until the entry is saved
     return subPath ? `${internalPath}/${subPath}/-` : `${internalPath}/-`;
   });
-  const subDirectories = $derived.by(() => {
-    void $allAssets;
-
-    return selectedFolder ? getAssetSubDirectories(selectedFolder, currentSubPath) : [];
-  });
+  const subDirectories = $derived.by(() =>
+    selectedFolder ? getAssetSubDirectories(selectedFolder, currentSubPath) : [],
+  );
 
   const folderLabel = $derived(
     selectedFolder
@@ -268,15 +266,7 @@
         return false;
       }
 
-      // When browsing a subdirectory, only include files directly in that subdirectory
-      if (currentSubPath) {
-        const expectedDir = `${selectedFolder.internalPath}/${currentSubPath}`;
-
-        return getPathInfo(asset.path).dirname === expectedDir;
-      }
-
-      // At root level, only include files in the root (not in subdirectories)
-      return getPathInfo(asset.path).dirname === selectedFolder.internalPath;
+      return isInDirectDir(asset.path, selectedFolder.internalPath, currentSubPath);
     }
 
     const { dirname } = getPathInfo(asset.path);

--- a/src/lib/components/assets/browser/select-assets-dialog.svelte
+++ b/src/lib/components/assets/browser/select-assets-dialog.svelte
@@ -17,6 +17,7 @@
   import { getPathInfo } from '@sveltia/utils/file';
   import equal from 'fast-deep-equal';
 
+  import Breadcrumb from '$lib/components/assets/shared/breadcrumb.svelte';
   import CloudinaryPanel from '$lib/components/assets/browser/cloudinary-panel.svelte';
   import CreateFolderDialog from '$lib/components/assets/shared/create-folder-dialog.svelte';
   import ExternalAssetsPanel from '$lib/components/assets/browser/external-assets-panel.svelte';
@@ -181,8 +182,6 @@
     return selectedFolder ? getAssetSubDirectories(selectedFolder, currentSubPath) : [];
   });
 
-  const breadcrumbSegments = $derived(currentSubPath ? ['', ...currentSubPath.split('/')] : ['']);
-
   const folderLabel = $derived(
     selectedFolder
       ? (selectedFolder.fileName ?? selectedFolder.collectionName ?? _('global_assets'))
@@ -206,20 +205,6 @@
 
     segments.pop();
     currentSubPath = segments.join('/');
-    selectedResources = [];
-  };
-
-  /**
-   * Navigate to a specific breadcrumb segment.
-   * @param {number} index Index of the segment to navigate to.
-   */
-  const navigateToSegment = (index) => {
-    if (index === 0) {
-      currentSubPath = '';
-    } else {
-      currentSubPath = breadcrumbSegments.slice(1, index + 1).join('/');
-    }
-
     selectedResources = [];
   };
 
@@ -560,34 +545,21 @@
     <div role="none" id="{elementIdPrefix}-content-pane" class="content-pane">
       {#if isDefaultLibrary && selectedFolder}
         <div class="internal-panel" role="none">
-          <!-- Breadcrumb -->
-          <div role="navigation" class="breadcrumb" aria-label="Folder navigation">
-            <span class="segments">
-              {#each breadcrumbSegments as segment, index}
-                {#if index > 0}
-                  <Icon name="chevron_right" />
-                {/if}
-                <button
-                  class="crumb"
-                  class:active={index === breadcrumbSegments.length - 1}
-                  onclick={() => navigateToSegment(index)}
-                >
-                  {index === 0 ? folderLabel : decodeURIComponent(segment)}
-                </button>
-              {/each}
-            </span>
-            {#if currentSubPath && !forFolder}
-              <Button variant="text" size="small" label={_('go_up')} onclick={navigateUp} />
-            {/if}
-            {#if canCreateInFolder && !forFolder}
-              <Button
-                variant="text"
-                size="small"
-                label={_('assets_dialog.create_folder')}
-                onclick={() => (showCreateFolderDialog = true)}
-              />
-            {/if}
-          </div>
+          <Breadcrumb
+            bind:currentSubPath
+            rootLabel={folderLabel}
+            showUpButton={!!currentSubPath && !forFolder}
+            showCreateButton={canCreateInFolder && !forFolder}
+            onNavigate={() => {
+              selectedResources = [];
+            }}
+            onNavigateUp={() => {
+              selectedResources = [];
+            }}
+            onCreateFolder={() => {
+              showCreateFolderDialog = true;
+            }}
+          />
           <div class="internal-panel-body" role="none">
             <InternalAssetsPanel
               {accept}
@@ -743,46 +715,8 @@
     min-height: 0;
   }
 
-  .breadcrumb {
-    /* Keep in sync with assets-page.svelte breadcrumb styles */
-    flex: none;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 0;
-    border-bottom: 1px solid var(--sui-control-border-color);
-    margin-bottom: 8px;
-
-    .segments {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      flex: auto;
-
-      .crumb {
-        cursor: pointer;
-        border: none;
-        border-radius: 4px;
-        padding: 2px 6px;
-        color: var(--sui-link-color);
-        background: none;
-        font-size: var(--sui-font-size-small);
-        font-family: inherit;
-
-        &:hover {
-          text-decoration: underline;
-        }
-
-        &.active {
-          cursor: default;
-          color: var(--sui-primary-foreground-color);
-          font-weight: var(--sui-font-weight-semi-bold);
-
-          &:hover {
-            text-decoration: none;
-          }
-        }
-      }
-    }
+  .internal-panel :global(.breadcrumb) {
+    --breadcrumb-padding: 8px 0;
+    --breadcrumb-margin-bottom: 8px;
   }
 </style>

--- a/src/lib/components/assets/browser/select-assets-dialog.svelte
+++ b/src/lib/components/assets/browser/select-assets-dialog.svelte
@@ -598,9 +598,9 @@
               basePath={selectedFolder.internalPath}
               {subDirectories}
               onNavigateFolder={(subDir) => navigateToSubPath(subDir.path)}
-          chooseFolders={forFolder}
-          onNavigateUp={currentSubPath ? navigateUp : undefined}
-          {currentSubPath}
+              chooseFolders={forFolder}
+              onNavigateUp={currentSubPath ? navigateUp : undefined}
+              {currentSubPath}
               onDrop={({ files }) => {
                 onDrop(files);
               }}

--- a/src/lib/components/assets/browser/select-assets-dialog.svelte
+++ b/src/lib/components/assets/browser/select-assets-dialog.svelte
@@ -18,10 +18,12 @@
   import equal from 'fast-deep-equal';
 
   import CloudinaryPanel from '$lib/components/assets/browser/cloudinary-panel.svelte';
+  import CreateFolderDialog from '$lib/components/assets/shared/create-folder-dialog.svelte';
   import ExternalAssetsPanel from '$lib/components/assets/browser/external-assets-panel.svelte';
   import InternalAssetsPanel from '$lib/components/assets/browser/internal-assets-panel.svelte';
   import ViewSwitcher from '$lib/components/common/page-toolbar/view-switcher.svelte';
-  import { allAssets } from '$lib/services/assets';
+  import { allAssets, getAssetSubDirectories } from '$lib/services/assets';
+  import { canCreateAsset } from '$lib/services/assets/folders';
   import { selectAssetsView, showContentOverlay } from '$lib/services/contents/editor';
   import {
     convertFileItemToAsset,
@@ -68,6 +70,7 @@
    * @property {File[]} [pendingFiles] Files to be uploaded to the cloud service panel when the
    * dialog opens. These are typically files dropped on the file editor when only a cloud service is
    * available.
+   * @property {boolean} [forFolder] Whether to select folders instead of files.
    * @property {(resources: SelectedResource[]) => void} [onSelect] Custom `Select` event handler
    * that will be called when the dialog is closed with the Insert button.
    */
@@ -87,6 +90,7 @@
     enabledCloudServiceEntries,
     onSelect = undefined,
     pendingFiles = $bindable([]),
+    forFolder = false,
     /* eslint-enable prefer-const */
   } = $props();
 
@@ -95,6 +99,8 @@
   let enteredURL = $state('');
   let rawSearchTerms = $state('');
   let libraryName = $state('default-global');
+  let currentSubPath = $state('');
+  let showCreateFolderDialog = $state(false);
   /** @type {Asset[]} */
   let droppedAssets = $state([]);
   /** @type {Asset[]} */
@@ -120,7 +126,11 @@
   };
 
   const title = $derived(
-    kind === 'image' ? _('assets_dialog.title.image') : _('assets_dialog.title.file'),
+    forFolder
+      ? _('assets_dialog.title.folder')
+      : kind === 'image'
+        ? _('assets_dialog.title.image')
+        : _('assets_dialog.title.file'),
   );
   const searchTerms = $derived(normalize(rawSearchTerms));
   const isDefaultLibraryEnabled = $derived(
@@ -144,7 +154,9 @@
 
     if (!entryRelative) {
       // @todo FIXME: Replace all template tags in the path, not just `{{slug}}`
-      return internalPath?.replace('{{slug}}', originalEntry?.slug ?? '-');
+      const basePath = internalPath?.replace('{{slug}}', originalEntry?.slug ?? '-') ?? '';
+
+      return currentSubPath ? `${basePath}/${currentSubPath}` : basePath;
     }
 
     // A non-empty `internalSubPath` means the field has its own `media_folder` subfolder (e.g.
@@ -155,12 +167,64 @@
     if (originalEntry) {
       const entryDir = getPathInfo(Object.values(originalEntry.locales)[0].path).dirname;
 
-      return subPath ? `${entryDir}/${subPath}` : entryDir;
+      const baseDir = subPath ? `${entryDir}/${subPath}` : entryDir;
+
+      return currentSubPath ? `${baseDir}/${currentSubPath}` : baseDir;
     }
 
     // Append a placeholder because the complete path is not determined until the entry is saved
     return subPath ? `${internalPath}/${subPath}/-` : `${internalPath}/-`;
   });
+  const subDirectories = $derived.by(() => {
+    void $allAssets;
+
+    return selectedFolder ? getAssetSubDirectories(selectedFolder, currentSubPath) : [];
+  });
+
+  const breadcrumbSegments = $derived(currentSubPath ? ['', ...currentSubPath.split('/')] : ['']);
+
+  const folderLabel = $derived(
+    selectedFolder
+      ? (selectedFolder.fileName ?? selectedFolder.collectionName ?? _('global_assets'))
+      : '',
+  );
+
+  /**
+   * Navigate to a subfolder path.
+   * @param {string} subPath Subfolder path relative to folder root.
+   */
+  const navigateToSubPath = (subPath) => {
+    currentSubPath = subPath ?? '';
+    selectedResources = [];
+  };
+
+  /**
+   * Navigate up one directory level.
+   */
+  const navigateUp = () => {
+    const segments = currentSubPath.split('/');
+
+    segments.pop();
+    currentSubPath = segments.join('/');
+    selectedResources = [];
+  };
+
+  /**
+   * Navigate to a specific breadcrumb segment.
+   * @param {number} index Index of the segment to navigate to.
+   */
+  const navigateToSegment = (index) => {
+    if (index === 0) {
+      currentSubPath = '';
+    } else {
+      currentSubPath = breadcrumbSegments.slice(1, index + 1).join('/');
+    }
+
+    selectedResources = [];
+  };
+
+  const canCreateInFolder = $derived(canCreateAsset(selectedFolder));
+
   const listedAssets = $derived(
     [...$allAssets, ...unsavedAssets]
       .filter((asset) => !kind || kind === asset.kind)
@@ -227,7 +291,19 @@
     }
 
     if (!selectedFolder.entryRelative) {
-      return isInTargetFolder(asset.path);
+      if (!isInTargetFolder(asset.path)) {
+        return false;
+      }
+
+      // When browsing a subdirectory, only include files directly in that subdirectory
+      if (currentSubPath) {
+        const expectedDir = `${selectedFolder.internalPath}/${currentSubPath}`;
+
+        return getPathInfo(asset.path).dirname === expectedDir;
+      }
+
+      // At root level of the folder, only include files directly in the root (not in subdirs)
+      return getPathInfo(asset.path).dirname === selectedFolder.internalPath;
     }
 
     const { dirname } = getPathInfo(asset.path);
@@ -295,6 +371,7 @@
     droppedAssets = [];
     unsavedAssets = [];
     selectedResources = [];
+    currentSubPath = '';
   };
 
   /**
@@ -306,6 +383,11 @@
     }
 
     const resources = $state.snapshot(selectedResources).map((resource) => {
+      // For folder selection mode, convert asset-based selection to a URL path
+      if (forFolder && resource.asset) {
+        return { url: resource.asset.path };
+      }
+
       const { unsaved, file, folder } = resource.asset ?? {};
 
       return unsaved ? { file, folder } : resource;
@@ -395,6 +477,7 @@
   size="x-large"
   okLabel={_('insert')}
   okDisabled={!selectedResources.length}
+  cancelLabel={_('cancel')}
   keepContent={true}
   focusInput={false}
   bind:open
@@ -428,6 +511,7 @@
         filterThreshold={-1}
         onChange={(event) => {
           libraryName = event.detail.name;
+          currentSubPath = '';
           selectedResources = [];
         }}
       >
@@ -475,17 +559,54 @@
     </div>
     <div role="none" id="{elementIdPrefix}-content-pane" class="content-pane">
       {#if isDefaultLibrary && selectedFolder}
-        <InternalAssetsPanel
-          {accept}
-          {multiple}
-          assets={listedAssets.filter(isAssetInSelectedFolder)}
-          bind:selectedResources
-          {searchTerms}
-          basePath={selectedFolder.internalPath}
-          onDrop={({ files }) => {
-            onDrop(files);
-          }}
-        />
+        <div class="internal-panel" role="none">
+          <!-- Breadcrumb -->
+          <div role="navigation" class="breadcrumb" aria-label="Folder navigation">
+            <span class="segments">
+              {#each breadcrumbSegments as segment, index}
+                {#if index > 0}
+                  <Icon name="chevron_right" />
+                {/if}
+                <button
+                  class="crumb"
+                  class:active={index === breadcrumbSegments.length - 1}
+                  onclick={() => navigateToSegment(index)}
+                >
+                  {index === 0 ? folderLabel : decodeURIComponent(segment)}
+                </button>
+              {/each}
+            </span>
+            {#if currentSubPath && !forFolder}
+              <Button variant="text" size="small" label={_('go_up')} onclick={navigateUp} />
+            {/if}
+            {#if canCreateInFolder && !forFolder}
+              <Button
+                variant="text"
+                size="small"
+                label={_('assets_dialog.create_folder')}
+                onclick={() => (showCreateFolderDialog = true)}
+              />
+            {/if}
+          </div>
+          <div class="internal-panel-body" role="none">
+            <InternalAssetsPanel
+              {accept}
+              {multiple}
+              assets={listedAssets.filter(isAssetInSelectedFolder)}
+              bind:selectedResources
+              {searchTerms}
+              basePath={selectedFolder.internalPath}
+              {subDirectories}
+              onNavigateFolder={(subDir) => navigateToSubPath(subDir.path)}
+          chooseFolders={forFolder}
+          onNavigateUp={currentSubPath ? navigateUp : undefined}
+          {currentSubPath}
+              onDrop={({ files }) => {
+                onDrop(files);
+              }}
+            />
+          </div>
+        </div>
       {/if}
       {#if canEnterURL && libraryName === 'enter-url'}
         <EmptyState>
@@ -562,6 +683,15 @@
   }}
 />
 
+<CreateFolderDialog
+  open={showCreateFolderDialog}
+  parentFolder={selectedFolder}
+  {currentSubPath}
+  onClose={() => {
+    showCreateFolderDialog = false;
+  }}
+/>
+
 <style lang="scss">
   .wrapper {
     display: flex;
@@ -599,5 +729,60 @@
   .filter-tools {
     display: flex;
     gap: 8px;
+  }
+
+  .internal-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+
+  .internal-panel-body {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .breadcrumb {
+    /* Keep in sync with assets-page.svelte breadcrumb styles */
+    flex: none;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--sui-control-border-color);
+    margin-bottom: 8px;
+
+    .segments {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      flex: auto;
+
+      .crumb {
+        cursor: pointer;
+        border: none;
+        border-radius: 4px;
+        padding: 2px 6px;
+        color: var(--sui-link-color);
+        background: none;
+        font-size: var(--sui-font-size-small);
+        font-family: inherit;
+
+        &:hover {
+          text-decoration: underline;
+        }
+
+        &.active {
+          cursor: default;
+          color: var(--sui-primary-foreground-color);
+          font-weight: var(--sui-font-weight-semi-bold);
+
+          &:hover {
+            text-decoration: none;
+          }
+        }
+      }
+    }
   }
 </style>

--- a/src/lib/components/assets/browser/simple-image-grid-item.svelte
+++ b/src/lib/components/assets/browser/simple-image-grid-item.svelte
@@ -13,6 +13,7 @@
    * @property {ViewType} [viewType] View type.
    * @property {boolean} multiple Whether to allow selecting multiple assets.
    * @property {(event: CustomEvent) => void} onChange Custom `Change` event handler.
+   * @property {() => void} [ondblclick] Double-click handler.
    * @property {Snippet} children Slot content.
    */
 
@@ -24,12 +25,13 @@
     viewType = 'grid',
     multiple,
     onChange,
+    ondblclick,
     children,
     /* eslint-enable prefer-const */
   } = $props();
 </script>
 
-<div role="none" class="wrapper {viewType}">
+<div role="none" class="wrapper {viewType}" {ondblclick}>
   <Option label="" {value} {selected} {onChange}>
     {#snippet startIcon()}
       {#if multiple}

--- a/src/lib/components/assets/list/asset-list.svelte
+++ b/src/lib/components/assets/list/asset-list.svelte
@@ -17,6 +17,9 @@
     targetAssetFolder,
   } from '$lib/services/assets/folders';
   import { currentView, listedAssets } from '$lib/services/assets/view';
+  import { filterAssets } from '$lib/services/assets/view/filter';
+  import { groupAssets } from '$lib/services/assets/view/group';
+  import { sortAssets } from '$lib/services/assets/view/sort';
 
   /**
    * @import { Asset } from '$lib/types/private';
@@ -34,7 +37,6 @@
    * @property {string} [currentSubPath] Current sub-path within the folder.
    * @property {(subDir: SubDirectory) => void} [onNavigateFolder] Called when a subdirectory is
    * clicked.
-   * @property {() => void} [onNavigateUp] Called when the "go up" button is clicked.
    */
 
   /** @type {Props} */
@@ -43,7 +45,6 @@
     subDirectories = [],
     currentSubPath = '',
     onNavigateFolder = undefined,
-    onNavigateUp = undefined,
     /* eslint-enable prefer-const */
   } = $props();
 
@@ -70,6 +71,15 @@
 
       return dirname === base;
     });
+  });
+
+  const groupedEntries = $derived.by(() => {
+    let assets = [...filteredAssets];
+
+    assets = sortAssets(assets, $currentView.sort);
+    assets = filterAssets(assets, $currentView.filter);
+
+    return Object.entries(groupAssets(assets, $currentView.group));
   });
 
   const showContent = $derived(subDirectories.length > 0 || filteredAssets.length > 0);
@@ -101,17 +111,19 @@
                 />
               {/each}
             {/if}
-            {#if filteredAssets.length}
-              <InfiniteScroll items={filteredAssets} itemKey="path">
-                {#snippet renderItem(/** @type {Asset} */ asset)}
-                  {#key asset.sha}
-                    {#await sleep() then}
-                      <AssetListItem {asset} {viewType} />
-                    {/await}
-                  {/key}
-                {/snippet}
-              </InfiniteScroll>
-            {/if}
+            {#each groupedEntries as [name, assets] (name)}
+              {#await sleep() then}
+                <InfiniteScroll items={assets} itemKey="path">
+                  {#snippet renderItem(/** @type {Asset} */ asset)}
+                    {#key asset.sha}
+                      {#await sleep() then}
+                        <AssetListItem {asset} {viewType} />
+                      {/await}
+                    {/key}
+                  {/snippet}
+                </InfiniteScroll>
+              {/await}
+            {/each}
           </GridBody>
         {/await}
       </ListingGrid>

--- a/src/lib/components/assets/list/asset-list.svelte
+++ b/src/lib/components/assets/list/asset-list.svelte
@@ -1,22 +1,22 @@
 <script>
   import { _ } from '@sveltia/i18n';
-  import { EmptyState, Icon, InfiniteScroll } from '@sveltia/ui';
+  import { EmptyState, GridBody, InfiniteScroll } from '@sveltia/ui';
   import { getPathInfo } from '@sveltia/utils/file';
   import { sleep } from '@sveltia/utils/misc';
-  import { stripSlashes } from '@sveltia/utils/string';
 
-  import AssetPath from '$lib/components/assets/browser/asset-path.svelte';
-  import SimpleImageGridItem from '$lib/components/assets/browser/simple-image-grid-item.svelte';
-  import SimpleImageGrid from '$lib/components/assets/browser/simple-image-grid.svelte';
-  import AssetPreview from '$lib/components/assets/shared/asset-preview.svelte';
+  import AssetListItem from '$lib/components/assets/list/asset-list-item.svelte';
+  import FolderItem from '$lib/components/assets/list/folder-item.svelte';
   import DropZone from '$lib/components/assets/shared/drop-zone.svelte';
   import UploadAssetsButton from '$lib/components/assets/toolbar/upload-assets-button.svelte';
   import ListContainer from '$lib/components/common/list-container.svelte';
-  import { goto } from '$lib/services/app/navigation';
-  import { focusedAsset, uploadingAssets, selectedAssets, selectedAssetPathSet } from '$lib/services/assets';
-  import { canCreateAsset, selectedAssetFolder, targetAssetFolder } from '$lib/services/assets/folders';
+  import ListingGrid from '$lib/components/common/listing-grid.svelte';
+  import { uploadingAssets } from '$lib/services/assets';
+  import {
+    canCreateAsset,
+    selectedAssetFolder,
+    targetAssetFolder,
+  } from '$lib/services/assets/folders';
   import { currentView, listedAssets } from '$lib/services/assets/view';
-  import { isSmallScreen } from '$lib/services/user/env';
 
   /**
    * @import { Asset } from '$lib/types/private';
@@ -50,65 +50,29 @@
   const viewType = $derived($currentView.type);
   const folder = $derived($targetAssetFolder);
   const uploadDisabled = $derived(!canCreateAsset(folder));
-  const isRootLevel = $derived(!currentSubPath);
-
-  const basePath = $derived($targetAssetFolder?.internalPath);
 
   const filteredAssets = $derived.by(() => {
     const selectedFolder = $selectedAssetFolder;
     const base = selectedFolder?.internalPath;
 
-    // All Assets is a virtual folder — show all assets flat.
     if (!base) {
       return $listedAssets;
     }
 
     if (currentSubPath) {
       const expectedDir = `${base}/${currentSubPath}`;
+
       return $listedAssets.filter((asset) => getPathInfo(asset.path).dirname === expectedDir);
     }
 
-    // At root level, only show files directly in this folder, not in subdirectories.
     return $listedAssets.filter((asset) => {
       const dirname = getPathInfo(asset.path).dirname ?? '';
+
       return dirname === base;
     });
   });
 
   const showContent = $derived(subDirectories.length > 0 || filteredAssets.length > 0);
-
-  /**
-   * Toggle file selection and set the focused asset.
-   * @param {Asset} asset Asset.
-   * @param {boolean} selected Whether selected.
-   */
-  const toggleSelection = (asset, selected) => {
-    if (selected) {
-      $focusedAsset = asset;
-    }
-
-    selectedAssets.update((assets) => {
-      const idx = assets.indexOf(asset);
-
-      if (selected && idx === -1) {
-        assets.push(asset);
-      } else if (!selected && idx > -1) {
-        assets.splice(idx, 1);
-      }
-
-      return assets;
-    });
-  };
-
-  /**
-   * Open asset detail on double-click.
-   * @param {Asset} asset Asset.
-   */
-  const openAssetDetail = (asset) => {
-    if (asset.kind !== 'other') {
-      goto(`/assets/${asset.path}`, { transitionType: 'forwards' });
-    }
-  };
 </script>
 
 <ListContainer aria-label={_('asset_list')}>
@@ -120,68 +84,37 @@
     }}
   >
     {#if showContent}
-      <div role="none" class="grid-wrapper">
-        <SimpleImageGrid {viewType} showTitle={true}>
-          {#if subDirectories.length}
-            {#if !isRootLevel && onNavigateUp}
-              <SimpleImageGridItem
-                value=".."
-                {viewType}
-                multiple={false}
-                selected={false}
-                onChange={() => onNavigateUp()}
-              >
-                <span role="none" class="dir-preview {viewType}">
-                  <Icon name="arrow_upward" />
-                </span>
-                <AssetPath path=".." />
-              </SimpleImageGridItem>
+      <ListingGrid
+        id="asset-list"
+        {viewType}
+        aria-label={_('assets')}
+        aria-rowcount={$listedAssets.length}
+      >
+        {#await sleep() then}
+          <GridBody>
+            {#if subDirectories.length}
+              {#each subDirectories as subDir (subDir.path)}
+                <FolderItem
+                  title={subDir.name}
+                  onclick={() => onNavigateFolder?.(subDir)}
+                  {viewType}
+                />
+              {/each}
             {/if}
-            {#each subDirectories as subDir (subDir.path)}
-              <SimpleImageGridItem
-                value={subDir.path}
-                {viewType}
-                multiple={false}
-                selected={false}
-                onChange={() => onNavigateFolder?.(subDir)}
-              >
-                <span role="none" class="dir-preview {viewType}">
-                  <Icon name="folder" />
-                </span>
-                <AssetPath path={subDir.name} />
-              </SimpleImageGridItem>
-            {/each}
-          {/if}
-          {#if filteredAssets.length}
-            <InfiniteScroll items={filteredAssets} itemKey="path">
-              {#snippet renderItem(/** @type {Asset} */ asset)}
-                {#await sleep() then}
-                  {@const { kind, name, path } = asset}
-                  {@const relPath =
-                    basePath ? stripSlashes(path.replace(basePath, '')) : name}
-                  <SimpleImageGridItem
-                    value={path}
-                    {viewType}
-                    multiple={true}
-                    selected={$selectedAssetPathSet.has(path)}
-                    onChange={({ detail: { selected } }) => toggleSelection(asset, selected)}
-                  >
-                    <div
-                      role="none"
-                      ondblclick={() => openAssetDetail(asset)}
-                    >
-                      <AssetPreview {kind} {asset} alt={relPath} variant="tile" checkerboard={kind === 'image'} />
-                    </div>
-                    {#if !$isSmallScreen || viewType === 'list'}
-                      <AssetPath path={relPath} />
-                    {/if}
-                  </SimpleImageGridItem>
-                {/await}
-              {/snippet}
-            </InfiniteScroll>
-          {/if}
-        </SimpleImageGrid>
-      </div>
+            {#if filteredAssets.length}
+              <InfiniteScroll items={filteredAssets} itemKey="path">
+                {#snippet renderItem(/** @type {Asset} */ asset)}
+                  {#key asset.sha}
+                    {#await sleep() then}
+                      <AssetListItem {asset} {viewType} />
+                    {/await}
+                  {/key}
+                {/snippet}
+              </InfiniteScroll>
+            {/if}
+          </GridBody>
+        {/await}
+      </ListingGrid>
     {:else}
       <EmptyState>
         <span role="none">{_('no_files_found')}</span>
@@ -192,42 +125,3 @@
     {/if}
   </DropZone>
 </ListContainer>
-
-<style lang="scss">
-  .grid-wrapper {
-    overflow-y: auto;
-    height: 100%;
-
-    :global([role='listbox']) {
-      background-color: transparent;
-    }
-
-    .dir-preview {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      aspect-ratio: 1 / 1;
-      border: 1px solid var(--sui-control-border-color);
-      border-radius: var(--sui-control-medium-border-radius);
-      background-color: var(--sui-secondary-background-color);
-      width: 100%;
-
-      :global(.icon) {
-        font-size: 48px;
-        color: var(--sui-secondary-foreground-color);
-        opacity: 0.6;
-      }
-
-      &.list {
-        width: 64px;
-        aspect-ratio: unset;
-        height: 64px;
-        flex: none;
-
-        :global(.icon) {
-          font-size: 24px;
-        }
-      }
-    }
-  }
-</style>

--- a/src/lib/components/assets/list/asset-list.svelte
+++ b/src/lib/components/assets/list/asset-list.svelte
@@ -1,7 +1,6 @@
 <script>
   import { _ } from '@sveltia/i18n';
   import { EmptyState, GridBody, InfiniteScroll } from '@sveltia/ui';
-  import { getPathInfo } from '@sveltia/utils/file';
   import { sleep } from '@sveltia/utils/misc';
 
   import AssetListItem from '$lib/components/assets/list/asset-list-item.svelte';
@@ -11,30 +10,21 @@
   import ListContainer from '$lib/components/common/list-container.svelte';
   import ListingGrid from '$lib/components/common/listing-grid.svelte';
   import { uploadingAssets } from '$lib/services/assets';
-  import {
-    canCreateAsset,
-    selectedAssetFolder,
-    targetAssetFolder,
-  } from '$lib/services/assets/folders';
-  import { currentView, listedAssets } from '$lib/services/assets/view';
+  import { canCreateAsset, targetAssetFolder } from '$lib/services/assets/folders';
+  import { currentView } from '$lib/services/assets/view';
   import { filterAssets } from '$lib/services/assets/view/filter';
   import { groupAssets } from '$lib/services/assets/view/group';
   import { sortAssets } from '$lib/services/assets/view/sort';
 
   /**
-   * @import { Asset } from '$lib/types/private';
-   */
-
-  /**
-   * @typedef {object} SubDirectory
-   * @property {string} name Subdirectory name.
-   * @property {string} path Subdirectory path relative to the base folder.
+   * @import { Asset, SubDirectory } from '$lib/types/private';
    */
 
   /**
    * @typedef {object} Props
    * @property {SubDirectory[]} [subDirectories] Subdirectories of the current folder.
    * @property {string} [currentSubPath] Current sub-path within the folder.
+   * @property {Asset[]} [filteredAssets] Assets filtered to the current folder and sub-path.
    * @property {(subDir: SubDirectory) => void} [onNavigateFolder] Called when a subdirectory is
    * clicked.
    */
@@ -44,6 +34,7 @@
     /* eslint-disable prefer-const */
     subDirectories = [],
     currentSubPath = '',
+    filteredAssets = [],
     onNavigateFolder = undefined,
     /* eslint-enable prefer-const */
   } = $props();
@@ -51,27 +42,6 @@
   const viewType = $derived($currentView.type);
   const folder = $derived($targetAssetFolder);
   const uploadDisabled = $derived(!canCreateAsset(folder));
-
-  const filteredAssets = $derived.by(() => {
-    const selectedFolder = $selectedAssetFolder;
-    const base = selectedFolder?.internalPath;
-
-    if (!base) {
-      return $listedAssets;
-    }
-
-    if (currentSubPath) {
-      const expectedDir = `${base}/${currentSubPath}`;
-
-      return $listedAssets.filter((asset) => getPathInfo(asset.path).dirname === expectedDir);
-    }
-
-    return $listedAssets.filter((asset) => {
-      const dirname = getPathInfo(asset.path).dirname ?? '';
-
-      return dirname === base;
-    });
-  });
 
   const groupedEntries = $derived.by(() => {
     let assets = [...filteredAssets];
@@ -98,7 +68,7 @@
         id="asset-list"
         {viewType}
         aria-label={_('assets')}
-        aria-rowcount={$listedAssets.length}
+        aria-rowcount={filteredAssets.length + subDirectories.length}
       >
         {#await sleep() then}
           <GridBody>

--- a/src/lib/components/assets/list/asset-list.svelte
+++ b/src/lib/components/assets/list/asset-list.svelte
@@ -1,24 +1,114 @@
 <script>
   import { _ } from '@sveltia/i18n';
-  import { EmptyState, GridBody, InfiniteScroll } from '@sveltia/ui';
+  import { EmptyState, Icon, InfiniteScroll } from '@sveltia/ui';
+  import { getPathInfo } from '@sveltia/utils/file';
   import { sleep } from '@sveltia/utils/misc';
+  import { stripSlashes } from '@sveltia/utils/string';
 
-  import AssetListItem from '$lib/components/assets/list/asset-list-item.svelte';
+  import AssetPath from '$lib/components/assets/browser/asset-path.svelte';
+  import SimpleImageGridItem from '$lib/components/assets/browser/simple-image-grid-item.svelte';
+  import SimpleImageGrid from '$lib/components/assets/browser/simple-image-grid.svelte';
+  import AssetPreview from '$lib/components/assets/shared/asset-preview.svelte';
   import DropZone from '$lib/components/assets/shared/drop-zone.svelte';
   import UploadAssetsButton from '$lib/components/assets/toolbar/upload-assets-button.svelte';
   import ListContainer from '$lib/components/common/list-container.svelte';
-  import ListingGrid from '$lib/components/common/listing-grid.svelte';
-  import { uploadingAssets } from '$lib/services/assets';
-  import { canCreateAsset, targetAssetFolder } from '$lib/services/assets/folders';
-  import { assetGroups, currentView, listedAssets } from '$lib/services/assets/view';
+  import { goto } from '$lib/services/app/navigation';
+  import { focusedAsset, uploadingAssets, selectedAssets, selectedAssetPathSet } from '$lib/services/assets';
+  import { canCreateAsset, selectedAssetFolder, targetAssetFolder } from '$lib/services/assets/folders';
+  import { currentView, listedAssets } from '$lib/services/assets/view';
+  import { isSmallScreen } from '$lib/services/user/env';
 
   /**
    * @import { Asset } from '$lib/types/private';
    */
 
+  /**
+   * @typedef {object} SubDirectory
+   * @property {string} name Subdirectory name.
+   * @property {string} path Subdirectory path relative to the base folder.
+   */
+
+  /**
+   * @typedef {object} Props
+   * @property {SubDirectory[]} [subDirectories] Subdirectories of the current folder.
+   * @property {string} [currentSubPath] Current sub-path within the folder.
+   * @property {(subDir: SubDirectory) => void} [onNavigateFolder] Called when a subdirectory is
+   * clicked.
+   * @property {() => void} [onNavigateUp] Called when the "go up" button is clicked.
+   */
+
+  /** @type {Props} */
+  let {
+    /* eslint-disable prefer-const */
+    subDirectories = [],
+    currentSubPath = '',
+    onNavigateFolder = undefined,
+    onNavigateUp = undefined,
+    /* eslint-enable prefer-const */
+  } = $props();
+
   const viewType = $derived($currentView.type);
   const folder = $derived($targetAssetFolder);
   const uploadDisabled = $derived(!canCreateAsset(folder));
+  const isRootLevel = $derived(!currentSubPath);
+
+  const basePath = $derived($targetAssetFolder?.internalPath);
+
+  const filteredAssets = $derived.by(() => {
+    const selectedFolder = $selectedAssetFolder;
+    const base = selectedFolder?.internalPath;
+
+    // All Assets is a virtual folder — show all assets flat.
+    if (!base) {
+      return $listedAssets;
+    }
+
+    if (currentSubPath) {
+      const expectedDir = `${base}/${currentSubPath}`;
+      return $listedAssets.filter((asset) => getPathInfo(asset.path).dirname === expectedDir);
+    }
+
+    // At root level, only show files directly in this folder, not in subdirectories.
+    return $listedAssets.filter((asset) => {
+      const dirname = getPathInfo(asset.path).dirname ?? '';
+      return dirname === base;
+    });
+  });
+
+  const showContent = $derived(subDirectories.length > 0 || filteredAssets.length > 0);
+
+  /**
+   * Toggle file selection and set the focused asset.
+   * @param {Asset} asset Asset.
+   * @param {boolean} selected Whether selected.
+   */
+  const toggleSelection = (asset, selected) => {
+    if (selected) {
+      $focusedAsset = asset;
+    }
+
+    selectedAssets.update((assets) => {
+      const idx = assets.indexOf(asset);
+
+      if (selected && idx === -1) {
+        assets.push(asset);
+      } else if (!selected && idx > -1) {
+        assets.splice(idx, 1);
+      }
+
+      return assets;
+    });
+  };
+
+  /**
+   * Open asset detail on double-click.
+   * @param {Asset} asset Asset.
+   */
+  const openAssetDetail = (asset) => {
+    if (asset.kind !== 'other') {
+      goto(`/assets/${asset.path}`, { transitionType: 'forwards' });
+    }
+  };
 </script>
 
 <ListContainer aria-label={_('asset_list')}>
@@ -26,32 +116,72 @@
     disabled={uploadDisabled}
     multiple={true}
     onDrop={({ files }) => {
-      $uploadingAssets = { folder, files };
+      $uploadingAssets = { folder, files, subPath: currentSubPath || undefined };
     }}
   >
-    {#if Object.values($assetGroups).flat(1).length}
-      <ListingGrid
-        id="asset-list"
-        {viewType}
-        aria-label={_('assets')}
-        aria-rowcount={$listedAssets.length}
-      >
-        {#each Object.entries($assetGroups) as [name, assets] (name)}
-          {#await sleep() then}
-            <GridBody label={name !== '*' ? name : undefined}>
-              <InfiniteScroll items={assets} itemKey="path">
-                {#snippet renderItem(/** @type {Asset} */ asset)}
-                  {#key asset.sha}
-                    {#await sleep() then}
-                      <AssetListItem {asset} {viewType} />
-                    {/await}
-                  {/key}
-                {/snippet}
-              </InfiniteScroll>
-            </GridBody>
-          {/await}
-        {/each}
-      </ListingGrid>
+    {#if showContent}
+      <div role="none" class="grid-wrapper">
+        <SimpleImageGrid {viewType} showTitle={true}>
+          {#if subDirectories.length}
+            {#if !isRootLevel && onNavigateUp}
+              <SimpleImageGridItem
+                value=".."
+                {viewType}
+                multiple={false}
+                selected={false}
+                onChange={() => onNavigateUp()}
+              >
+                <span role="none" class="dir-preview {viewType}">
+                  <Icon name="arrow_upward" />
+                </span>
+                <AssetPath path=".." />
+              </SimpleImageGridItem>
+            {/if}
+            {#each subDirectories as subDir (subDir.path)}
+              <SimpleImageGridItem
+                value={subDir.path}
+                {viewType}
+                multiple={false}
+                selected={false}
+                onChange={() => onNavigateFolder?.(subDir)}
+              >
+                <span role="none" class="dir-preview {viewType}">
+                  <Icon name="folder" />
+                </span>
+                <AssetPath path={subDir.name} />
+              </SimpleImageGridItem>
+            {/each}
+          {/if}
+          {#if filteredAssets.length}
+            <InfiniteScroll items={filteredAssets} itemKey="path">
+              {#snippet renderItem(/** @type {Asset} */ asset)}
+                {#await sleep() then}
+                  {@const { kind, name, path } = asset}
+                  {@const relPath =
+                    basePath ? stripSlashes(path.replace(basePath, '')) : name}
+                  <SimpleImageGridItem
+                    value={path}
+                    {viewType}
+                    multiple={true}
+                    selected={$selectedAssetPathSet.has(path)}
+                    onChange={({ detail: { selected } }) => toggleSelection(asset, selected)}
+                  >
+                    <div
+                      role="none"
+                      ondblclick={() => openAssetDetail(asset)}
+                    >
+                      <AssetPreview {kind} {asset} alt={relPath} variant="tile" checkerboard={kind === 'image'} />
+                    </div>
+                    {#if !$isSmallScreen || viewType === 'list'}
+                      <AssetPath path={relPath} />
+                    {/if}
+                  </SimpleImageGridItem>
+                {/await}
+              {/snippet}
+            </InfiniteScroll>
+          {/if}
+        </SimpleImageGrid>
+      </div>
     {:else}
       <EmptyState>
         <span role="none">{_('no_files_found')}</span>
@@ -62,3 +192,42 @@
     {/if}
   </DropZone>
 </ListContainer>
+
+<style lang="scss">
+  .grid-wrapper {
+    overflow-y: auto;
+    height: 100%;
+
+    :global([role='listbox']) {
+      background-color: transparent;
+    }
+
+    .dir-preview {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      aspect-ratio: 1 / 1;
+      border: 1px solid var(--sui-control-border-color);
+      border-radius: var(--sui-control-medium-border-radius);
+      background-color: var(--sui-secondary-background-color);
+      width: 100%;
+
+      :global(.icon) {
+        font-size: 48px;
+        color: var(--sui-secondary-foreground-color);
+        opacity: 0.6;
+      }
+
+      &.list {
+        width: 64px;
+        aspect-ratio: unset;
+        height: 64px;
+        flex: none;
+
+        :global(.icon) {
+          font-size: 24px;
+        }
+      }
+    }
+  }
+</style>

--- a/src/lib/components/assets/list/folder-item.svelte
+++ b/src/lib/components/assets/list/folder-item.svelte
@@ -1,6 +1,7 @@
 <script>
-  import { GridCell, GridRow, Icon, TruncatedText } from '@sveltia/ui';
+  import { GridCell, GridRow, TruncatedText } from '@sveltia/ui';
 
+  import FolderPreview from '$lib/components/assets/shared/folder-preview.svelte';
   import { isMediumScreen, isSmallScreen } from '$lib/services/user/env';
 
   /**
@@ -29,11 +30,7 @@
     <GridCell class="checkbox" />
   {/if}
   <GridCell class="image">
-    <span class="dir-preview {viewType}">
-      <span role="none">
-        <Icon name="folder" />
-      </span>
-    </span>
+    <FolderPreview {viewType} />
   </GridCell>
   {#if !$isSmallScreen || viewType === 'list'}
     <GridCell class="title">
@@ -49,42 +46,5 @@
 <style lang="scss">
   .label {
     word-break: break-all;
-  }
-
-  .dir-preview {
-    display: block;
-    &.grid {
-      padding: 12px;
-    }
-
-    & > span {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      aspect-ratio: 1 / 1;
-
-      :global(.icon) {
-        font-size: 48px;
-        color: var(--sui-secondary-foreground-color);
-        opacity: 0.6;
-      }
-    }
-
-    &.grid > span {
-      border: 1px solid var(--sui-control-border-color);
-      border-radius: var(--sui-control-medium-border-radius);
-      background-color: var(--sui-secondary-background-color);
-    }
-
-    &.list > span {
-      width: 48px;
-      aspect-ratio: unset;
-      height: 48px;
-      flex: none;
-
-      :global(.icon) {
-        font-size: 24px;
-      }
-    }
   }
 </style>

--- a/src/lib/components/assets/list/folder-item.svelte
+++ b/src/lib/components/assets/list/folder-item.svelte
@@ -11,8 +11,8 @@
   /**
    * @typedef {object} Props
    * @property {string} title Title.
-   * @property {() => void} onclick onClick.
-   * @property {ViewType} viewType ViewType.
+   * @property {() => void} onclick Click handler.
+   * @property {ViewType} viewType View type.
    */
 
   /** @type {Props} */

--- a/src/lib/components/assets/list/folder-item.svelte
+++ b/src/lib/components/assets/list/folder-item.svelte
@@ -1,0 +1,90 @@
+<script>
+  import { GridCell, GridRow, Icon, TruncatedText } from '@sveltia/ui';
+
+  import { isMediumScreen, isSmallScreen } from '$lib/services/user/env';
+
+  /**
+   * @import { ViewType } from '$lib/types/private';
+   */
+
+  /**
+   * @typedef {object} Props
+   * @property {string} title Title.
+   * @property {() => void} onclick onClick.
+   * @property {ViewType} viewType ViewType.
+   */
+
+  /** @type {Props} */
+  let {
+    /* eslint-disable prefer-const */
+    title,
+    onclick,
+    viewType,
+    /* eslint-enable prefer-const */
+  } = $props();
+</script>
+
+<GridRow {onclick}>
+  {#if !($isSmallScreen || $isMediumScreen)}
+    <GridCell class="checkbox" />
+  {/if}
+  <GridCell class="image">
+    <span class="dir-preview {viewType}">
+      <span role="none">
+        <Icon name="folder" />
+      </span>
+    </span>
+  </GridCell>
+  {#if !$isSmallScreen || viewType === 'list'}
+    <GridCell class="title">
+      <div role="none" class="label">
+        <TruncatedText lines={2}>
+          {title}
+        </TruncatedText>
+      </div>
+    </GridCell>
+  {/if}
+</GridRow>
+
+<style lang="scss">
+  .label {
+    word-break: break-all;
+  }
+
+  .dir-preview {
+    display: block;
+    &.grid {
+      padding: 12px;
+    }
+
+    & > span {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      aspect-ratio: 1 / 1;
+
+      :global(.icon) {
+        font-size: 48px;
+        color: var(--sui-secondary-foreground-color);
+        opacity: 0.6;
+      }
+    }
+
+    &.grid > span {
+      border: 1px solid var(--sui-control-border-color);
+      border-radius: var(--sui-control-medium-border-radius);
+      background-color: var(--sui-secondary-background-color);
+    }
+
+    &.list > span {
+      width: 48px;
+      aspect-ratio: unset;
+      height: 48px;
+      flex: none;
+
+      :global(.icon) {
+        font-size: 24px;
+      }
+    }
+  }
+</style>

--- a/src/lib/components/assets/list/primary-sidebar.svelte
+++ b/src/lib/components/assets/list/primary-sidebar.svelte
@@ -19,12 +19,14 @@
   /**
    * @typedef {object} Props
    * @property {boolean} [isSearchPage] Whether the current page is the search results page.
+   * @property {() => void} [onSelect] Called when a folder is selected.
    */
 
   /** @type {Props} */
   let {
     /* eslint-disable prefer-const */
     isSearchPage = false,
+    onSelect = undefined,
     /* eslint-enable prefer-const */
   } = $props();
 
@@ -73,6 +75,7 @@
             selected={$isSmallScreen || isSearchPage ? false : selected}
             label={appLocale.current ? getFolderLabelByCollection(folder) : ''}
             onSelect={() => {
+              onSelect?.();
               goto(`/assets/${internalPath ?? '-/all'}`, {
                 transitionType: 'forwards',
                 // An internal path can be shared by multiple collections, files and fields. Pass

--- a/src/lib/components/assets/list/secondary-toolbar.svelte
+++ b/src/lib/components/assets/list/secondary-toolbar.svelte
@@ -12,13 +12,31 @@
   import { sortKeys } from '$lib/services/assets/view/sort-keys';
   import { isMediumScreen, isSmallScreen } from '$lib/services/user/env';
 
-  const hasListedAssets = $derived(!!$listedAssets.length);
-  const hasMultipleAssets = $derived($listedAssets.length > 1);
+  /**
+   * @import { Asset } from '$lib/types/private';
+   */
+
+  /**
+   * @typedef {object} Props
+   * @property {Asset[]} [filteredAssets] When set, overrides $listedAssets for the item selector
+   * and count checks (used when browsing a subfolder).
+   */
+
+  /** @type {Props} */
+  let {
+    /* eslint-disable prefer-const */
+    filteredAssets = undefined,
+    /* eslint-enable prefer-const */
+  } = $props();
+
+  const totalAssets = $derived(filteredAssets ?? $listedAssets);
+  const hasListedAssets = $derived(!!totalAssets.length);
+  const hasMultipleAssets = $derived(totalAssets.length > 1);
 </script>
 
 <Toolbar variant="secondary" aria-label={_('asset_list')}>
   {#if !($isSmallScreen || $isMediumScreen)}
-    <ItemSelector allItems={Object.values($assetGroups).flat(1)} selectedItems={selectedAssets} />
+    <ItemSelector allItems={totalAssets} selectedItems={selectedAssets} />
   {/if}
   <Spacer flex />
   <SortMenu

--- a/src/lib/components/assets/list/secondary-toolbar.svelte
+++ b/src/lib/components/assets/list/secondary-toolbar.svelte
@@ -8,7 +8,7 @@
   import ViewSwitcher from '$lib/components/common/page-toolbar/view-switcher.svelte';
   import { selectedAssets } from '$lib/services/assets';
   import { ASSET_KINDS } from '$lib/services/assets/kinds';
-  import { assetGroups, currentView, listedAssets } from '$lib/services/assets/view';
+  import { currentView, listedAssets } from '$lib/services/assets/view';
   import { sortKeys } from '$lib/services/assets/view/sort-keys';
   import { isMediumScreen, isSmallScreen } from '$lib/services/user/env';
 

--- a/src/lib/components/assets/shared/breadcrumb.svelte
+++ b/src/lib/components/assets/shared/breadcrumb.svelte
@@ -2,7 +2,20 @@
   import { _ } from '@sveltia/i18n';
   import { Button, Icon } from '@sveltia/ui';
 
+  /**
+   * @typedef {object} Props
+   * @property {string} [currentSubPath] Current sub-path.
+   * @property {string} [rootLabel] Root folder label.
+   * @property {boolean} [showUpButton] Whether to show the up button.
+   * @property {boolean} [showCreateButton] Whether to show the create folder button.
+   * @property {() => void} [onCreateFolder] Create folder callback.
+   * @property {() => void} [onNavigate] Navigate callback.
+   * @property {() => void} [onNavigateUp] Navigate up callback.
+   */
+
+  /** @type {Props} */
   let {
+    /* eslint-disable prefer-const */
     currentSubPath = $bindable(''),
     rootLabel = '',
     showUpButton = false,
@@ -10,10 +23,14 @@
     onCreateFolder = () => {},
     onNavigate = () => {},
     onNavigateUp = () => {},
+    /* eslint-enable prefer-const */
   } = $props();
 
   const breadcrumbSegments = $derived(currentSubPath ? ['', ...currentSubPath.split('/')] : ['']);
 
+  /**
+   * Navigate up one directory level.
+   */
   const navigateUp = () => {
     const segments = currentSubPath.split('/');
 
@@ -22,6 +39,10 @@
     onNavigateUp();
   };
 
+  /**
+   * Navigate to a breadcrumb segment by index.
+   * @param {number} index Segment index.
+   */
   const navigateToSegment = (index) => {
     if (index === 0) {
       currentSubPath = '';
@@ -35,7 +56,7 @@
 
 <div role="navigation" class="breadcrumb" aria-label="Folder navigation">
   <span class="segments">
-    {#each breadcrumbSegments as segment, index}
+    {#each breadcrumbSegments as segment, index (index)}
       {#if index > 0}
         <Icon name="chevron_right" />
       {/if}
@@ -44,16 +65,24 @@
         class:active={index === breadcrumbSegments.length - 1}
         onclick={() => navigateToSegment(index)}
       >
-        {index === 0 ? rootLabel : decodeURIComponent(segment)}
+        {index === 0
+          ? rootLabel
+          : (() => {
+              try {
+                return decodeURIComponent(segment);
+              } catch {
+                return segment;
+              }
+            })()}
       </button>
     {/each}
   </span>
   {#if showUpButton}
-    <Button variant="text" size="small" label={_('go_up')} onclick={navigateUp} />
+    <Button variant="tertiary" size="small" label={_('go_up')} onclick={navigateUp} />
   {/if}
   {#if showCreateButton}
     <Button
-      variant="text"
+      variant="tertiary"
       size="small"
       label={_('assets_dialog.create_folder')}
       onclick={onCreateFolder}
@@ -68,7 +97,6 @@
     align-items: center;
     gap: 8px;
     padding: var(--breadcrumb-padding, 8px 16px);
-    border-bottom: 1px solid var(--sui-control-border-color);
     margin-bottom: var(--breadcrumb-margin-bottom, 0);
 
     .segments {

--- a/src/lib/components/assets/shared/breadcrumb.svelte
+++ b/src/lib/components/assets/shared/breadcrumb.svelte
@@ -1,0 +1,106 @@
+<script>
+  import { _ } from '@sveltia/i18n';
+  import { Button, Icon } from '@sveltia/ui';
+
+  let {
+    currentSubPath = $bindable(''),
+    rootLabel = '',
+    showUpButton = false,
+    showCreateButton = false,
+    onCreateFolder = () => {},
+    onNavigate = () => {},
+    onNavigateUp = () => {},
+  } = $props();
+
+  const breadcrumbSegments = $derived(currentSubPath ? ['', ...currentSubPath.split('/')] : ['']);
+
+  const navigateUp = () => {
+    const segments = currentSubPath.split('/');
+
+    segments.pop();
+    currentSubPath = segments.join('/');
+    onNavigateUp();
+  };
+
+  const navigateToSegment = (index) => {
+    if (index === 0) {
+      currentSubPath = '';
+    } else {
+      currentSubPath = breadcrumbSegments.slice(1, index + 1).join('/');
+    }
+
+    onNavigate();
+  };
+</script>
+
+<div role="navigation" class="breadcrumb" aria-label="Folder navigation">
+  <span class="segments">
+    {#each breadcrumbSegments as segment, index}
+      {#if index > 0}
+        <Icon name="chevron_right" />
+      {/if}
+      <button
+        class="crumb"
+        class:active={index === breadcrumbSegments.length - 1}
+        onclick={() => navigateToSegment(index)}
+      >
+        {index === 0 ? rootLabel : decodeURIComponent(segment)}
+      </button>
+    {/each}
+  </span>
+  {#if showUpButton}
+    <Button variant="text" size="small" label={_('go_up')} onclick={navigateUp} />
+  {/if}
+  {#if showCreateButton}
+    <Button
+      variant="text"
+      size="small"
+      label={_('assets_dialog.create_folder')}
+      onclick={onCreateFolder}
+    />
+  {/if}
+</div>
+
+<style lang="scss">
+  .breadcrumb {
+    flex: none;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: var(--breadcrumb-padding, 8px 16px);
+    border-bottom: 1px solid var(--sui-control-border-color);
+    margin-bottom: var(--breadcrumb-margin-bottom, 0);
+
+    .segments {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      flex: auto;
+
+      .crumb {
+        cursor: pointer;
+        border: none;
+        border-radius: 4px;
+        padding: 2px 6px;
+        color: var(--sui-link-color);
+        background: none;
+        font-size: var(--sui-font-size-small);
+        font-family: inherit;
+
+        &:hover {
+          text-decoration: underline;
+        }
+
+        &.active {
+          cursor: default;
+          color: var(--sui-primary-foreground-color);
+          font-weight: var(--sui-font-weight-semi-bold);
+
+          &:hover {
+            text-decoration: none;
+          }
+        }
+      }
+    }
+  }
+</style>

--- a/src/lib/components/assets/shared/breadcrumb.svelte
+++ b/src/lib/components/assets/shared/breadcrumb.svelte
@@ -54,7 +54,7 @@
   };
 </script>
 
-<div role="navigation" class="breadcrumb" aria-label="Folder navigation">
+<div role="navigation" class="breadcrumb" aria-label={_('folder_navigation')}>
   <span class="segments">
     {#each breadcrumbSegments as segment, index (index)}
       {#if index > 0}

--- a/src/lib/components/assets/shared/create-folder-dialog.svelte
+++ b/src/lib/components/assets/shared/create-folder-dialog.svelte
@@ -1,0 +1,125 @@
+<script>
+  import { _ } from '@sveltia/i18n';
+  import { Dialog, TextInput } from '@sveltia/ui';
+
+  import { createFolder } from '$lib/services/assets/data/create';
+
+  /**
+   * @import { AssetFolderInfo } from '$lib/types/private';
+   */
+
+  /**
+   * @typedef {object} Props
+   * @property {boolean} open Whether the dialog is open.
+   * @property {AssetFolderInfo | undefined} parentFolder Parent folder info.
+   * @property {string} [currentSubPath] Current sub-path within the parent folder.
+   * @property {() => void} onClose Close handler.
+   */
+
+  /** @type {Props} */
+  let {
+    /* eslint-disable prefer-const */
+    open = $bindable(false),
+    parentFolder,
+    currentSubPath = '',
+    onClose,
+    /* eslint-enable prefer-const */
+  } = $props();
+
+  let folderName = $state('');
+  let errorMessage = $state('');
+
+  /**
+   * Convert a string to a filesystem-safe folder name.
+   * @param {string} str Input string.
+   * @returns {string} Sanitized folder name.
+   */
+  const sanitizeFolderName = (str) => str.trim();
+
+  /**
+   * Validate the folder name.
+   * @returns {boolean} Whether the name is valid.
+   */
+  const isValid = () => {
+    if (!folderName.trim()) {
+      errorMessage = _('assets_dialog.folder_name_empty');
+
+      return false;
+    }
+
+    // eslint-disable-next-line no-control-regex
+    if (/[<>:"/\\|?*\x00-\x1f]/.test(folderName)) {
+      errorMessage = _('assets_dialog.folder_name_character');
+
+      return false;
+    }
+
+    errorMessage = '';
+
+    return true;
+  };
+
+  /**
+   * Handle the Create button click.
+   */
+  const onCreate = async () => {
+    if (!isValid()) {
+      return;
+    }
+
+    await createFolder(sanitizeFolderName(folderName), parentFolder, currentSubPath);
+
+    folderName = '';
+    open = false;
+    onClose();
+  };
+
+  /**
+   * Handle the dialog close.
+   */
+  const handleClose = () => {
+    folderName = '';
+    errorMessage = '';
+    open = false;
+    onClose();
+  };
+</script>
+
+<Dialog
+  title={_('assets_dialog.create_folder')}
+  size="small"
+  okLabel="Create"
+  bind:open
+  onOk={onCreate}
+  onClose={handleClose}
+>
+  <TextInput
+    dir="auto"
+    flex
+    bind:value={folderName}
+    placeholder={_('assets_dialog.enter_folder_name')}
+    aria-label={_('assets_dialog.enter_folder_name')}
+    autofocus
+    oninput={() => {
+      if (errorMessage) {
+        errorMessage = '';
+      }
+    }}
+    onkeydown={(event) => {
+      if (event.key === 'Enter') {
+        onCreate();
+      }
+    }}
+  />
+  {#if errorMessage}
+    <div role="alert" class="error">{errorMessage}</div>
+  {/if}
+</Dialog>
+
+<style lang="scss">
+  .error {
+    margin-top: 8px;
+    color: var(--sui-error-foreground-color);
+    font-size: var(--sui-font-size-small);
+  }
+</style>

--- a/src/lib/components/assets/shared/create-folder-dialog.svelte
+++ b/src/lib/components/assets/shared/create-folder-dialog.svelte
@@ -30,11 +30,11 @@
   let errorMessage = $state('');
 
   /**
-   * Convert a string to a filesystem-safe folder name.
+   * Trim whitespace from a folder name.
    * @param {string} str Input string.
-   * @returns {string} Sanitized folder name.
+   * @returns {string} Trimmed folder name.
    */
-  const sanitizeFolderName = (str) => str.trim();
+  const trimFolderName = (str) => str.trim();
 
   /**
    * Validate the folder name.
@@ -67,7 +67,13 @@
       return;
     }
 
-    await createFolder(sanitizeFolderName(folderName), parentFolder, currentSubPath);
+    try {
+      await createFolder(trimFolderName(folderName), parentFolder, currentSubPath);
+    } catch (e) {
+      errorMessage = /** @type {Error} */ (e).message;
+
+      return;
+    }
 
     folderName = '';
     open = false;
@@ -88,7 +94,7 @@
 <Dialog
   title={_('assets_dialog.create_folder')}
   size="small"
-  okLabel="Create"
+  okLabel={_('create')}
   bind:open
   onOk={onCreate}
   onClose={handleClose}

--- a/src/lib/components/assets/shared/create-folder-dialog.svelte
+++ b/src/lib/components/assets/shared/create-folder-dialog.svelte
@@ -95,6 +95,7 @@
   title={_('assets_dialog.create_folder')}
   size="small"
   okLabel={_('create')}
+  cancelLabel={_('cancel')}
   bind:open
   onOk={onCreate}
   onClose={handleClose}

--- a/src/lib/components/assets/shared/folder-preview.svelte
+++ b/src/lib/components/assets/shared/folder-preview.svelte
@@ -1,0 +1,60 @@
+<script>
+  import { Icon } from '@sveltia/ui';
+
+  /**
+   * @import { ViewType } from '$lib/types/private';
+   */
+
+  /**
+   * @typedef {object} Props
+   * @property {ViewType} viewType ViewType.
+   */
+
+  /** @type {Props} */
+  let {
+    /* eslint-disable prefer-const */
+    viewType,
+    /* eslint-enable prefer-const */
+  } = $props();
+</script>
+
+<span class="dir-preview {viewType}">
+  <span role="none">
+    <Icon name="folder" />
+  </span>
+</span>
+
+<style>
+  .dir-preview {
+    display: block;
+
+    &.grid {
+      padding: 12px;
+    }
+
+    & > span {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      aspect-ratio: 1 / 1;
+      width: 100%;
+      height: 100%;
+    }
+
+    &.grid > span {
+      border: 1px solid var(--sui-control-border-color);
+      border-radius: var(--sui-control-medium-border-radius);
+      background-color: var(--sui-secondary-background-color);
+
+      :global(.icon) {
+        font-size: 48px;
+        color: var(--sui-secondary-foreground-color);
+        opacity: 0.6;
+      }
+    }
+
+    &.list :global(.icon) {
+      font-size: 36px;
+    }
+  }
+</style>

--- a/src/lib/components/assets/shared/upload-assets-confirm-dialog.svelte
+++ b/src/lib/components/assets/shared/upload-assets-confirm-dialog.svelte
@@ -13,7 +13,7 @@
   // eslint-disable-next-line svelte/prefer-writable-derived
   let files = $state([]);
 
-  const { files: originalFiles, folder, originalAsset } = $derived($uploadingAssets);
+  const { files: originalFiles, folder, originalAsset, subPath } = $derived($uploadingAssets);
   const { processing, undersizedFiles, oversizedFiles, transformedFileMap } =
     $derived($processedAssets);
   const { max_file_size: maxSize } = $derived(getDefaultMediaLibraryOptions().config);
@@ -36,9 +36,10 @@
   open={$showUploadAssetsConfirmDialog}
   title={_(originalAsset ? 'replace_asset' : 'upload_assets')}
   okLabel={_(originalAsset ? 'replace' : 'upload')}
+  cancelLabel={_('cancel')}
   okDisabled={!files.length}
   onOk={async () => {
-    await saveAssets({ files, folder, originalAsset }, { commitType: 'uploadMedia' });
+    await saveAssets({ files, folder, originalAsset, subPath }, { commitType: 'uploadMedia' });
     $uploadingAssets = { folder: undefined, files: [] };
   }}
   onCancel={() => {
@@ -59,7 +60,16 @@
           })}
         {:else}
           {_('confirm_uploading_files', {
-            values: { count: files.length, folder: `/${folder?.internalPath}` },
+            values: {
+              count: files.length,
+              folder: folder?.internalPath
+                ? subPath
+                  ? `/${folder.internalPath}/${subPath}`
+                  : `/${folder.internalPath}`
+                : subPath
+                  ? `/${subPath}`
+                  : '',
+            },
           })}
         {/if}
       </div>

--- a/src/lib/components/assets/shared/upload-assets-confirm-dialog.svelte
+++ b/src/lib/components/assets/shared/upload-assets-confirm-dialog.svelte
@@ -18,6 +18,14 @@
     $derived($processedAssets);
   const { max_file_size: maxSize } = $derived(getDefaultMediaLibraryOptions().config);
 
+  const targetFolderLabel = $derived.by(() => {
+    if (folder?.internalPath) {
+      return subPath ? `/${folder.internalPath}/${subPath}` : `/${folder.internalPath}`;
+    }
+
+    return subPath ? `/${subPath}` : '';
+  });
+
   $effect(() => {
     files = [...undersizedFiles];
   });
@@ -62,13 +70,7 @@
           {_('confirm_uploading_files', {
             values: {
               count: files.length,
-              folder: folder?.internalPath
-                ? subPath
-                  ? `/${folder.internalPath}/${subPath}`
-                  : `/${folder.internalPath}`
-                : subPath
-                  ? `/${subPath}`
-                  : '',
+              folder: targetFolderLabel,
             },
           })}
         {/if}

--- a/src/lib/components/assets/shared/upload-assets-dialog.svelte
+++ b/src/lib/components/assets/shared/upload-assets-dialog.svelte
@@ -6,7 +6,11 @@
   import DropZone from '$lib/components/assets/shared/drop-zone.svelte';
   import { uploadingAssets } from '$lib/services/assets';
   import { targetAssetFolder } from '$lib/services/assets/folders';
-  import { currentAssetSubPath, showAssetOverlay, showUploadAssetsDialog } from '$lib/services/assets/view';
+  import {
+    currentAssetSubPath,
+    showAssetOverlay,
+    showUploadAssetsDialog,
+  } from '$lib/services/assets/view';
   import { hasMouse } from '$lib/services/user/env';
 
   /** @type {FilePicker | undefined} */

--- a/src/lib/components/assets/shared/upload-assets-dialog.svelte
+++ b/src/lib/components/assets/shared/upload-assets-dialog.svelte
@@ -6,7 +6,7 @@
   import DropZone from '$lib/components/assets/shared/drop-zone.svelte';
   import { uploadingAssets } from '$lib/services/assets';
   import { targetAssetFolder } from '$lib/services/assets/folders';
-  import { showAssetOverlay, showUploadAssetsDialog } from '$lib/services/assets/view';
+  import { currentAssetSubPath, showAssetOverlay, showUploadAssetsDialog } from '$lib/services/assets/view';
   import { hasMouse } from '$lib/services/user/env';
 
   /** @type {FilePicker | undefined} */
@@ -31,6 +31,7 @@
       folder: originalAsset ? originalAsset.folder : $targetAssetFolder,
       files,
       originalAsset,
+      subPath: $currentAssetSubPath || undefined,
     };
     $showUploadAssetsDialog = false;
   };

--- a/src/lib/components/common/listing-grid.svelte
+++ b/src/lib/components/common/listing-grid.svelte
@@ -203,6 +203,7 @@
 
           &.image {
             width: 48px;
+            text-align: center;
 
             &:empty::before {
               display: block;

--- a/src/lib/components/contents/details/fields/file/file-editor-item.svelte
+++ b/src/lib/components/contents/details/fields/file/file-editor-item.svelte
@@ -32,6 +32,7 @@
    * @property {() => void} [onRemove] Event handler for remove action.
    * @property {() => void} [onMoveUp] Event handler for move up action.
    * @property {() => void} [onMoveDown] Event handler for move down action.
+   * @property {boolean} [isFolderField] Whether this field selects folders instead of files.
    */
 
   /** @type {Props} */
@@ -50,6 +51,7 @@
     onRemove,
     onMoveUp,
     onMoveDown,
+    isFolderField = false,
   } = $props();
 
   /** @type {Asset | undefined} */
@@ -184,7 +186,11 @@
       </Button>
     </div>
   {/if}
-  {#if kind && src}
+  {#if isFolderField}
+    <span role="none" class="preview no-thumbnail">
+      <Icon name="folder" />
+    </span>
+  {:else if kind && src}
     <AssetPreview {kind} {src} variant="tile" checkerboard={true} />
   {:else if asset}
     <AssetPreview kind={asset.kind} {asset} variant="tile" checkerboard={true} />
@@ -216,7 +222,7 @@
           variant="tertiary"
           size="small"
           label={_('replace')}
-          aria-label={_(`replace_${fieldType}`)}
+          aria-label={isFolderField ? _('replace_folder') : _(`replace_${fieldType}`)}
           aria-controls="{fieldId}-value"
           onclick={() => {
             onReplace();
@@ -229,7 +235,7 @@
           variant="tertiary"
           size="small"
           label={_('remove')}
-          aria-label={_(`remove_${fieldType}`)}
+          aria-label={isFolderField ? _('remove_folder') : _(`remove_${fieldType}`)}
           aria-controls="{fieldId}-value"
           onclick={() => {
             onRemove();

--- a/src/lib/components/contents/details/fields/file/file-editor.svelte
+++ b/src/lib/components/contents/details/fields/file/file-editor.svelte
@@ -85,6 +85,7 @@
   const fileName = $derived($entryDraft?.fileName);
   const isIndexFile = $derived($entryDraft?.isIndexFile ?? false);
   const isImageField = $derived(fieldType === 'image');
+  const isFolderField = $derived(fieldConfig.select_folder ?? false);
   const defaultLibraryOptions = $derived(getDefaultMediaLibraryOptions({ fieldConfig }));
   const libraryConfig = $derived(defaultLibraryOptions.config);
   const assetLibraryFolderMap = $derived(
@@ -113,6 +114,7 @@
     fileName,
     typedKeyPath,
     entry,
+    isFolderField: isFolderField,
   });
   const enabledCloudServiceEntries = $derived(
     Object.entries(allCloudStorageServices).filter(
@@ -375,6 +377,7 @@
   {fieldConfig}
   {assetLibraryFolderMap}
   {enabledCloudServiceEntries}
+  forFolder={isFolderField}
   bind:open={showSelectAssetsDialog}
   bind:pendingFiles
   onSelect={onResourcesSelect}

--- a/src/lib/components/contents/details/fields/file/file-editor.svelte
+++ b/src/lib/components/contents/details/fields/file/file-editor.svelte
@@ -114,7 +114,7 @@
     fileName,
     typedKeyPath,
     entry,
-    isFolderField: isFolderField,
+    isFolderField,
   });
   const enabledCloudServiceEntries = $derived(
     Object.entries(allCloudStorageServices).filter(

--- a/src/lib/locales/en.yaml
+++ b/src/lib/locales/en.yaml
@@ -21,7 +21,7 @@ working_with_test_repo: Working with Test Repository
 sign_out: Sign Out
 create: New
 go_up: Go Up
-open_folder: Open “{$name}”
+folder_navigation: Folder navigation
 select: Select
 select_all: Select All
 upload: Upload

--- a/src/lib/locales/en.yaml
+++ b/src/lib/locales/en.yaml
@@ -20,6 +20,8 @@ working_with_local_repo: Working with Local Repository
 working_with_test_repo: Working with Test Repository
 sign_out: Sign Out
 create: New
+go_up: Go Up
+open_folder: Open “{$name}”
 select: Select
 select_all: Select All
 upload: Upload
@@ -266,6 +268,8 @@ enter_new_name_for_asset_error:
   character: File name cannot contain special characters.
   duplicate: This file name is used for another asset.
 replace_asset: Replace Asset
+replace_folder: Replace Folder
+remove_folder: Remove Folder
 replace_x: Replace {$name}
 click_to_browse: Click to browse…
 tap_to_browse: Tap to browse…
@@ -629,6 +633,7 @@ assets_dialog:
   title:
     file: Select File
     image: Select Image
+    folder: Select Folder
   search_for_file: Search for Files
   search_for_image: Search for Images
   locations: Locations
@@ -652,6 +657,10 @@ assets_dialog:
     title: Photo Credit
     description: "Use the following credit if possible:"
   unsaved: Unsaved
+  create_folder: Create Folder
+  enter_folder_name: Enter folder name
+  folder_name_empty: Folder name cannot be empty.
+  folder_name_character: Folder name cannot contain special characters.
 character_counter:
   min_max: |
     .input {$count :integer}

--- a/src/lib/services/assets/data/create.js
+++ b/src/lib/services/assets/data/create.js
@@ -27,12 +27,16 @@ import { formatFileName } from '$lib/services/utils/file';
  * object.
  */
 export const createFileList = (uploadingAssets) => {
-  const { files, folder, originalAsset } = uploadingAssets;
+  const { files, folder, originalAsset, subPath } = uploadingAssets;
   const { slugify_filename: slugificationEnabled = false } = getDefaultMediaLibraryOptions().config;
 
+  const targetDir = subPath && folder?.internalPath
+    ? [folder.internalPath, subPath].join('/')
+    : folder?.internalPath;
+
   const assetNamesInSameFolder =
-    folder?.internalPath !== undefined
-      ? getAssetsByDirName(folder.internalPath).map((a) => a.name.normalize())
+    targetDir !== undefined
+      ? getAssetsByDirName(targetDir).map((a) => a.name.normalize())
       : [];
 
   return files.map((file) => {
@@ -44,10 +48,14 @@ export const createFileList = (uploadingAssets) => {
       assetNamesInSameFolder.push(fileName);
     }
 
+    const filePath = originalAsset?.path ?? (subPath && folder?.internalPath
+      ? [folder.internalPath, subPath, fileName].join('/')
+      : targetDir ? [targetDir, fileName].join('/') : fileName);
+
     return {
       action: /** @type {CommitAction} */ (originalAsset ? 'update' : 'create'),
       name: fileName,
-      path: originalAsset?.path ?? [folder?.internalPath, fileName].join('/'),
+      path: filePath,
       file,
     };
   });
@@ -109,4 +117,37 @@ export const saveAssets = async (uploadingAssets, options) => {
   });
 
   updatedStores({ count: files.length });
+};
+
+/**
+ * Create a new empty folder by committing a `.gitkeep` file inside it.
+ * @param {string} name Folder name.
+ * @param {AssetFolderInfo | undefined} parentFolder The parent asset folder.
+ * @param {string} [currentSubPath] Current sub-path within the parent folder.
+ */
+export const createFolder = async (name, parentFolder, currentSubPath) => {
+  const basePath = parentFolder?.internalPath ?? '';
+
+  if (!basePath) {
+    return;
+  }
+
+  const folderPath = currentSubPath ? `${basePath}/${currentSubPath}/${name}` : `${basePath}/${name}`;
+
+  /** @type {Asset} */
+  const asset = {
+    name: '.gitkeep',
+    path: `${folderPath}/.gitkeep`,
+    size: 0,
+    kind: 'other',
+    folder: /** @type {AssetFolderInfo} */ (parentFolder),
+  };
+
+  await saveChanges({
+    changes: [{ action: 'create', path: `${folderPath}/.gitkeep`, data: new Blob(['']) }],
+    savingAssets: [asset],
+    options: {},
+  });
+
+  updatedStores({ count: 1 });
 };

--- a/src/lib/services/assets/data/create.js
+++ b/src/lib/services/assets/data/create.js
@@ -15,7 +15,8 @@ import { getDefaultMediaLibraryOptions } from '$lib/services/integrations/media-
 import { formatFileName } from '$lib/services/utils/file';
 
 /**
- * @import { Asset, CommitAction, CommitOptions, UploadingAssets } from '$lib/types/private';
+ * @import { Asset, AssetFolderInfo } from '$lib/types/private';
+ * @import { CommitAction, CommitOptions, UploadingAssets } from '$lib/types/private';
  */
 
 /**
@@ -47,13 +48,17 @@ export const createFileList = (uploadingAssets) => {
       assetNamesInSameFolder.push(fileName);
     }
 
-    const filePath =
-      originalAsset?.path ??
-      (subPath && folder?.internalPath
-        ? [folder.internalPath, subPath, fileName].join('/')
-        : targetDir
-          ? [targetDir, fileName].join('/')
-          : fileName);
+    let filePath;
+
+    if (originalAsset?.path) {
+      filePath = originalAsset.path;
+    } else if (subPath && folder?.internalPath) {
+      filePath = [folder.internalPath, subPath, fileName].join('/');
+    } else if (targetDir) {
+      filePath = [targetDir, fileName].join('/');
+    } else {
+      filePath = fileName;
+    }
 
     return {
       action: /** @type {CommitAction} */ (originalAsset ? 'update' : 'create'),
@@ -132,7 +137,7 @@ export const createFolder = async (name, parentFolder, currentSubPath) => {
   const basePath = parentFolder?.internalPath ?? '';
 
   if (!basePath) {
-    return;
+    throw new Error('Cannot create folder: no parent folder selected');
   }
 
   const folderPath = currentSubPath
@@ -143,15 +148,18 @@ export const createFolder = async (name, parentFolder, currentSubPath) => {
   const asset = {
     name: '.gitkeep',
     path: `${folderPath}/.gitkeep`,
+    sha: '',
     size: 0,
     kind: 'other',
     folder: /** @type {AssetFolderInfo} */ (parentFolder),
   };
 
   await saveChanges({
-    changes: [{ action: 'create', path: `${folderPath}/.gitkeep`, data: new Blob(['']) }],
+    changes: [
+      { action: 'create', path: `${folderPath}/.gitkeep`, data: new File([''], '.gitkeep') },
+    ],
     savingAssets: [asset],
-    options: {},
+    options: { commitType: 'uploadMedia' },
   });
 
   updatedStores({ count: 1 });

--- a/src/lib/services/assets/data/create.js
+++ b/src/lib/services/assets/data/create.js
@@ -30,14 +30,13 @@ export const createFileList = (uploadingAssets) => {
   const { files, folder, originalAsset, subPath } = uploadingAssets;
   const { slugify_filename: slugificationEnabled = false } = getDefaultMediaLibraryOptions().config;
 
-  const targetDir = subPath && folder?.internalPath
-    ? [folder.internalPath, subPath].join('/')
-    : folder?.internalPath;
+  const targetDir =
+    subPath && folder?.internalPath
+      ? [folder.internalPath, subPath].join('/')
+      : folder?.internalPath;
 
   const assetNamesInSameFolder =
-    targetDir !== undefined
-      ? getAssetsByDirName(targetDir).map((a) => a.name.normalize())
-      : [];
+    targetDir !== undefined ? getAssetsByDirName(targetDir).map((a) => a.name.normalize()) : [];
 
   return files.map((file) => {
     const fileName =
@@ -48,9 +47,13 @@ export const createFileList = (uploadingAssets) => {
       assetNamesInSameFolder.push(fileName);
     }
 
-    const filePath = originalAsset?.path ?? (subPath && folder?.internalPath
-      ? [folder.internalPath, subPath, fileName].join('/')
-      : targetDir ? [targetDir, fileName].join('/') : fileName);
+    const filePath =
+      originalAsset?.path ??
+      (subPath && folder?.internalPath
+        ? [folder.internalPath, subPath, fileName].join('/')
+        : targetDir
+          ? [targetDir, fileName].join('/')
+          : fileName);
 
     return {
       action: /** @type {CommitAction} */ (originalAsset ? 'update' : 'create'),
@@ -132,7 +135,9 @@ export const createFolder = async (name, parentFolder, currentSubPath) => {
     return;
   }
 
-  const folderPath = currentSubPath ? `${basePath}/${currentSubPath}/${name}` : `${basePath}/${name}`;
+  const folderPath = currentSubPath
+    ? `${basePath}/${currentSubPath}/${name}`
+    : `${basePath}/${name}`;
 
   /** @type {Asset} */
   const asset = {

--- a/src/lib/services/assets/data/create.js
+++ b/src/lib/services/assets/data/create.js
@@ -31,10 +31,11 @@ export const createFileList = (uploadingAssets) => {
   const { files, folder, originalAsset, subPath } = uploadingAssets;
   const { slugify_filename: slugificationEnabled = false } = getDefaultMediaLibraryOptions().config;
 
-  const targetDir =
-    subPath && folder?.internalPath
-      ? [folder.internalPath, subPath].join('/')
-      : folder?.internalPath;
+  const targetDir = folder?.internalPath
+    ? subPath
+      ? `${folder.internalPath}/${subPath}`
+      : folder.internalPath
+    : undefined;
 
   const assetNamesInSameFolder =
     targetDir !== undefined ? getAssetsByDirName(targetDir).map((a) => a.name.normalize()) : [];
@@ -48,17 +49,7 @@ export const createFileList = (uploadingAssets) => {
       assetNamesInSameFolder.push(fileName);
     }
 
-    let filePath;
-
-    if (originalAsset?.path) {
-      filePath = originalAsset.path;
-    } else if (subPath && folder?.internalPath) {
-      filePath = [folder.internalPath, subPath, fileName].join('/');
-    } else if (targetDir) {
-      filePath = [targetDir, fileName].join('/');
-    } else {
-      filePath = fileName;
-    }
+    const filePath = originalAsset?.path ?? (targetDir ? `${targetDir}/${fileName}` : fileName);
 
     return {
       action: /** @type {CommitAction} */ (originalAsset ? 'update' : 'create'),

--- a/src/lib/services/assets/index.js
+++ b/src/lib/services/assets/index.js
@@ -429,7 +429,9 @@ export const getAssetSubDirectories = (assetFolder, subPath) => {
   const paths = [
     ...get(allAssets).map((a) => a.path),
     // Also scan .gitkeep config files so folders with only a .gitkeep are visible
-    ...get(gitConfigFiles).filter((f) => f.name === '.gitkeep').map((f) => f.path),
+    ...get(gitConfigFiles)
+      .filter((f) => f.name === '.gitkeep')
+      .map((f) => f.path),
   ];
 
   paths.forEach((path) => {

--- a/src/lib/services/assets/index.js
+++ b/src/lib/services/assets/index.js
@@ -10,6 +10,7 @@ import {
   selectedAssetFolder,
 } from '$lib/services/assets/folders';
 import { processFile } from '$lib/services/assets/process';
+import { gitConfigFiles } from '$lib/services/backends/git/shared/config';
 import { fillTemplate } from '$lib/services/common/template';
 import { getCollection } from '$lib/services/contents/collection';
 import { isCollectionIndexFile } from '$lib/services/contents/collection/entries/index-file';
@@ -396,6 +397,60 @@ export const getAssetByPath = ({ value, entry, collectionName, fileName, typedKe
   }
 
   return getAssetByAbsolutePath({ path, entry, collectionName, fileName, typedKeyPath });
+};
+
+/**
+ * Get unique subdirectory names one level below a given path prefix within a configured asset
+ * folder, or at the repo root when `assetFolder` is the All Assets folder (no `internalPath`).
+ * This is derived from existing asset paths plus `.gitkeep` config files, so empty directories
+ * (containing only a `.gitkeep`) are also included.
+ * @param {AssetFolderInfo | undefined} assetFolder The selected asset folder.
+ * @param {string} [subPath] Current sub-path within the folder relative to the folder root.
+ * @returns {{ name: string, path: string }[]} Sorted subdirectory entries.
+ */
+export const getAssetSubDirectories = (assetFolder, subPath) => {
+  // Entry-relative folders have paths relative to entries, which don't map cleanly
+  // to absolute repo paths. Skip subdirectory scanning for these.
+  if (!assetFolder || assetFolder.entryRelative) {
+    return [];
+  }
+
+  // All Assets is a virtual folder with no concrete path — no subfolder navigation.
+  if (!assetFolder.internalPath) {
+    return [];
+  }
+
+  const base = assetFolder.internalPath;
+
+  const prefix = subPath ? `${base}/${subPath}/` : `${base}/`;
+
+  const dirs = new Map();
+
+  const paths = [
+    ...get(allAssets).map((a) => a.path),
+    // Also scan .gitkeep config files so folders with only a .gitkeep are visible
+    ...get(gitConfigFiles).filter((f) => f.name === '.gitkeep').map((f) => f.path),
+  ];
+
+  paths.forEach((path) => {
+    if (prefix && !path.startsWith(prefix)) {
+      return;
+    }
+
+    const searchIn = prefix ? path.slice(prefix.length) : path;
+    const slashIdx = searchIn.indexOf('/');
+
+    if (slashIdx > 0) {
+      const dirName = searchIn.slice(0, slashIdx);
+      const dirPath = subPath ? `${subPath}/${dirName}` : dirName;
+
+      if (!dirs.has(dirName)) {
+        dirs.set(dirName, { name: dirName, path: dirPath });
+      }
+    }
+  });
+
+  return Array.from(dirs.values()).sort((a, b) => a.name.localeCompare(b.name));
 };
 
 /**

--- a/src/lib/services/assets/index.js
+++ b/src/lib/services/assets/index.js
@@ -421,9 +421,7 @@ export const getAssetSubDirectories = (assetFolder, subPath) => {
   }
 
   const base = assetFolder.internalPath;
-
   const prefix = subPath ? `${base}/${subPath}/` : `${base}/`;
-
   const dirs = new Map();
 
   const paths = [

--- a/src/lib/services/assets/index.js
+++ b/src/lib/services/assets/index.js
@@ -400,6 +400,23 @@ export const getAssetByPath = ({ value, entry, collectionName, fileName, typedKe
 };
 
 /**
+ * Check if an asset path is directly inside a given folder directory (not in subdirectories).
+ * @param {string} assetPath Asset path.
+ * @param {string | undefined} basePath Base folder path.
+ * @param {string} [subPath] Optional sub-path within the base folder.
+ * @returns {boolean} `true` if the asset is directly in the target directory.
+ */
+export const isInDirectDir = (assetPath, basePath, subPath) => {
+  if (!basePath) {
+    return false;
+  }
+
+  const targetDir = subPath ? `${basePath}/${subPath}` : basePath;
+
+  return (getPathInfo(assetPath).dirname ?? '') === targetDir;
+};
+
+/**
  * Get unique subdirectory names one level below a given path prefix within a configured asset
  * folder, or at the repo root when `assetFolder` is the All Assets folder (no `internalPath`).
  * This is derived from existing asset paths plus `.gitkeep` config files, so empty directories

--- a/src/lib/services/assets/view/index.js
+++ b/src/lib/services/assets/view/index.js
@@ -30,6 +30,13 @@ export const showAssetOverlay = writable(false);
 export const showUploadAssetsDialog = writable(false);
 
 /**
+ * Current sub-path being browsed within an asset folder. Used to upload files into the right
+ * subdirectory.
+ * @type {Writable<string>}
+ */
+export const currentAssetSubPath = writable('');
+
+/**
  * @type {Readable<boolean>}
  */
 export const showUploadAssetsConfirmDialog = derived(

--- a/src/lib/types/private.js
+++ b/src/lib/types/private.js
@@ -786,6 +786,7 @@
  * @property {AssetFolderInfo | undefined} folder Target asset folder info.
  * @property {File[]} files File list.
  * @property {Asset} [originalAsset] Asset to be replaced.
+ * @property {string} [subPath] Current sub-path within the folder for target path.
  */
 
 /**

--- a/src/lib/types/private.js
+++ b/src/lib/types/private.js
@@ -445,6 +445,13 @@
  */
 
 /**
+ * Subdirectory entry within an asset folder.
+ * @typedef {object} SubDirectory
+ * @property {string} name Subdirectory name.
+ * @property {string} path Subdirectory path relative to the base folder.
+ */
+
+/**
  * File info being processed as {@link Entry}.
  * @typedef {BaseFileListItemProps & { type: 'entry', folder: EntryFolderInfo }} BaseEntryListItem
  */

--- a/src/lib/types/public.js
+++ b/src/lib/types/public.js
@@ -311,6 +311,9 @@
  * [`accept`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/accept)
  * attribute.
  * @property {boolean} [choose_url] Whether to show the URL input UI. Default: `true`.
+ * @property {boolean} [select_folder] Whether to allow selecting folders instead of files. When
+ * set to `true`, the media library will show only directories and selecting one will store its
+ * path as the field value. Default: `false`.
  * @property {string} [media_folder] Internal media folder path for the field. Default: global or
  * collection-level `media_folder` value.
  * @property {string} [public_folder] Public media folder path for the field. Default:


### PR DESCRIPTION
This is an attempt on implementing #420 

I know the project currently doesn't accept most PRs, but I need this feature desperately for my workflow to work with Sveltia CMS and as I authored it in Static CMS, I decided to just try my luck, assisted by OpenCode. I know that it might be simply rejected, and I am prepared to maintain it in my own fork as long as needed.

Implementation details:
- folders are being determined from asset path instead of fetching them from git
- both grid view and list view is implemented
- there is a breadcrumb navigation bar to move between folders
- selecting a folder instead of a file in field type file is possible when `select_folder: true` is set
- creating a folder places a .gitkeep file inside of it

I will thoroughly test this feature in production during the next weeks before confirming this PR as ready to merge. An opinion on the implementation would be nice however, @kyoshino.