### PR TITLE
fix(media-library): sort S3 assets by last modified date, newest first

### DIFF
--- a/src/lib/services/integrations/media-libraries/cloud/s3/core.js
+++ b/src/lib/services/integrations/media-libraries/cloud/s3/core.js
@@ -383,7 +383,11 @@ export const listS3Objects = async (config, options, { maxPages = 10 } = {}) => 
     ? allObjects.filter((obj) => getAssetKind(obj.Key) === kind)
     : allObjects;
 
-  return parseS3Results(filteredObjects, config);
+  // S3 returns objects in lexicographical key order; sort by last modified date, newest first, to
+  // match the behavior of other media libraries like Uploadcare
+  return parseS3Results(filteredObjects, config).sort(
+    (a, b) => (b.lastModified?.getTime() ?? 0) - (a.lastModified?.getTime() ?? 0),
+  );
 };
 
 /**

--- a/src/lib/services/integrations/media-libraries/cloud/s3/core.test.js
+++ b/src/lib/services/integrations/media-libraries/cloud/s3/core.test.js
@@ -508,8 +508,43 @@ describe('integrations/media-libraries/cloud/s3/shared utilities', () => {
       });
 
       expect(results).toHaveLength(2);
-      expect(results[0].fileName).toBe('image1.jpg');
-      expect(results[1].fileName).toBe('image2.png');
+      expect(results[0].fileName).toBe('image2.png');
+      expect(results[1].fileName).toBe('image1.jpg');
+    });
+
+    it('should sort objects by last modified date, newest first', async () => {
+      const xmlResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <Contents>
+    <Key>a-oldest.jpg</Key>
+    <LastModified>2025-01-01T00:00:00.000Z</LastModified>
+    <Size>1024</Size>
+  </Contents>
+  <Contents>
+    <Key>b-newest.jpg</Key>
+    <LastModified>2025-03-01T00:00:00.000Z</LastModified>
+    <Size>1024</Size>
+  </Contents>
+  <Contents>
+    <Key>c-middle.jpg</Key>
+    <LastModified>2025-02-01T00:00:00.000Z</LastModified>
+    <Size>1024</Size>
+  </Contents>
+  <IsTruncated>false</IsTruncated>
+</ListBucketResult>`;
+
+      vi.mocked(fetch).mockResolvedValue(new Response(xmlResponse, { status: 200 }));
+
+      const results = await listS3Objects(mockConfig, {
+        kind: undefined,
+        apiKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      });
+
+      expect(results.map((r) => r.fileName)).toEqual([
+        'b-newest.jpg',
+        'c-middle.jpg',
+        'a-oldest.jpg',
+      ]);
     });
 
     it('should filter by image kind', async () => {
@@ -721,8 +756,8 @@ describe('integrations/media-libraries/cloud/s3/shared utilities', () => {
       });
 
       expect(results).toHaveLength(2);
-      expect(results[0].fileName).toBe('vacation-photo.jpg');
-      expect(results[1].fileName).toBe('another-photo.jpg');
+      expect(results[0].fileName).toBe('another-photo.jpg');
+      expect(results[1].fileName).toBe('vacation-photo.jpg');
     });
 
     it('should be case-insensitive', async () => {


### PR DESCRIPTION
## Problem

S3 `ListObjectsV2` returns objects in lexicographical key order, so assets in S3-compatible media libraries (AWS S3, Cloudflare R2, DigitalOcean Spaces, etc.) appear sorted alphabetically by filename in the asset picker. Editors expect to see their most recently uploaded files first — with a few thousand files in a bucket, a new upload lands somewhere in the middle of the list and is effectively impossible to find.

Other cloud media libraries already behave this way: e.g. the Uploadcare integration lists with `ordering=-datetime_uploaded`.

## Fix

The `LastModified` date was already captured in `parseS3Results` but never used for ordering. This change sorts the listing by `lastModified` descending in `listS3Objects`. Search results inherit the same ordering since `searchS3Objects` filters the sorted listing.

## Tests

- Added a test asserting newest-first ordering in `listS3Objects`
- Updated two existing tests that implicitly asserted S3 key order
- All 266 tests in `media-libraries/cloud` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)