### PR TITLE
Fix regex injection in asset folder path matching

### DIFF
--- a/src/lib/services/assets/folders.js
+++ b/src/lib/services/assets/folders.js
@@ -1,7 +1,8 @@
 import { getPathInfo } from '@sveltia/utils/file';
+import { escapeRegExp } from '@sveltia/utils/string';
 import { derived, get, writable } from 'svelte/store';
 
-import { TEMPLATE_TAG_REPLACE_REGEX } from '$lib/services/common/template/constants';
+import { ESCAPED_PLACEHOLDER_REGEX } from '$lib/services/common/template/constants';
 
 /**
  * @import { Readable, Writable } from 'svelte/store';
@@ -108,13 +109,12 @@ const getAssetFolderPathCache = () => {
     } else {
       // Pre-compile both regex variants so we don’t recreate them on every path lookup.
       // The internal path can contain template tags like `{{slug}}`, which we normalize to `.+?`.
-      const normalizedPath = internalPath.replace(TEMPLATE_TAG_REPLACE_REGEX, '.+?');
+      const normalizedPath = escapeRegExp(internalPath).replace(ESCAPED_PLACEHOLDER_REGEX, '.+?');
 
       items.push({
         folder,
-        // `\b` anchors the match at the end of the folder segment (sub-folder matching).
-        // When `internalPath` is empty (root), fall back to `$` to avoid a bare `\b` anchor.
-        regexSub: new RegExp(`^${normalizedPath}${internalPath ? '\\b' : '$'}`),
+        // Match the end of the folder segment for sub-folder matching.
+        regexSub: new RegExp(`^${normalizedPath}${internalPath ? '(?=\\/|$)' : '$'}`),
         regexExact: new RegExp(`^${normalizedPath}$`),
       });
     }

--- a/src/lib/services/assets/folders.test.js
+++ b/src/lib/services/assets/folders.test.js
@@ -508,6 +508,34 @@ describe('assets/folders', () => {
       expect(result[0].internalPath).toBe('content/posts/{{slug}}');
     });
 
+    it('should treat regex metacharacters in folder paths as literals', () => {
+      allAssetFolders.set([
+        {
+          collectionName: 'posts',
+          internalPath: '(a+)+',
+          publicPath: '/assets',
+          entryRelative: false,
+          hasTemplateTags: false,
+        },
+      ]);
+
+      getPathInfoMock.mockReturnValue({
+        filename: 'image.jpg',
+        basename: 'image.jpg',
+        dirname: '(a+)+',
+      });
+
+      expect(getAssetFoldersByPath('(a+)+/image.jpg')).toHaveLength(1);
+
+      getPathInfoMock.mockReturnValue({
+        filename: 'image.jpg',
+        basename: 'image.jpg',
+        dirname: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA',
+      });
+
+      expect(getAssetFoldersByPath('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA/image.jpg')).toEqual([]);
+    });
+
     it('should match entry relative paths', () => {
       getPathInfoMock.mockReturnValue({
         filename: 'banner.jpg',


### PR DESCRIPTION
## Summary

This change escapes configured asset folder paths before compiling them into regular expressions. Template placeholders such as `{{slug}}` still work as intended, but ordinary path characters like `(`, `+`, `[`, `]`, and `.` are now treated literally.

The patch also replaces `\b` with a path segment boundary lookahead, because `\b` does not correctly represent folder boundaries when a path segment ends with a non-word character.

## Security note

Repository-controlled asset folder configuration should not be interpreted as arbitrary regular expression syntax during asset path lookup.

## Verification

```text
npx vitest run src/lib/services/assets/folders.test.js src/lib/services/config/folders/assets.test.js
2 test files passed, 131 tests passed.

npx eslint src/lib/services/assets/folders.js src/lib/services/assets/folders.test.js
passed
```