### PR TITLE
feat: add Backblaze B2 cloud media library support

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -22,6 +22,7 @@ words:
   - analyzing
   - astrolicious
   - astros
+  - Backblaze
   - backlink
   - backlinks
   - brotlied

--- a/src/lib/services/integrations/media-libraries/cloud/index.js
+++ b/src/lib/services/integrations/media-libraries/cloud/index.js
@@ -1,5 +1,6 @@
 import cloudinary from './cloudinary';
 import awsS3 from './s3/aws-s3';
+import backblazeB2 from './s3/backblaze-b2';
 import cloudflareR2 from './s3/cloudflare-r2';
 import digitaloceanSpaces from './s3/digitalocean-spaces';
 import scaleway from './s3/scaleway';
@@ -17,6 +18,7 @@ import uploadcare from './uploadcare';
  */
 export const allCloudStorageServices = {
   aws_s3: awsS3,
+  backblaze_b2: backblazeB2, // S3-compatible
   cloudflare_r2: cloudflareR2, // S3-compatible
   cloudinary,
   digitalocean_spaces: digitaloceanSpaces, // S3-compatible

--- a/src/lib/services/integrations/media-libraries/cloud/s3/backblaze-b2.js
+++ b/src/lib/services/integrations/media-libraries/cloud/s3/backblaze-b2.js
@@ -1,0 +1,109 @@
+import {
+  getLibraryOptions as getS3LibraryOptions,
+  listS3Objects,
+  searchS3Objects,
+  uploadToS3,
+} from './core';
+
+/**
+ * @import {
+ * ExternalAsset,
+ * MediaLibraryFetchOptions,
+ * MediaLibraryService,
+ * S3Config,
+ * } from '$lib/types/private';
+ * @import { CmsConfig, MediaField, S3MediaLibrary } from '$lib/types/public';
+ */
+
+/**
+ * Get Backblaze B2 library options from site config.
+ * @internal
+ * @param {CmsConfig | MediaField} [config] CMS configuration or field configuration.
+ * @returns {S3MediaLibrary | false | undefined} Configuration object, or `false` if explicitly
+ * disabled.
+ */
+export const getLibraryOptions = (config) => getS3LibraryOptions('backblaze_b2', config);
+
+/**
+ * Check if Backblaze B2 integration is enabled.
+ * @param {MediaField} [fieldConfig] Field configuration.
+ * @returns {boolean} True if enabled, false otherwise.
+ */
+export const isEnabled = (fieldConfig) => {
+  const options = getLibraryOptions(fieldConfig) ?? getLibraryOptions();
+
+  return !!(options && options.access_key_id && options.bucket && options.region);
+};
+
+/**
+ * Build the resolved S3 config for the given field or global Backblaze B2 library options.
+ * @param {MediaLibraryFetchOptions} options Options containing the configuration.
+ * @returns {S3Config} Resolved config.
+ * @throws {Error} If the Backblaze B2 configuration is not available.
+ */
+const getConfig = ({ fieldConfig }) => {
+  const libOptions = getLibraryOptions(fieldConfig) ?? getLibraryOptions();
+
+  if (!libOptions) {
+    throw new Error('Backblaze B2 configuration is not available');
+  }
+
+  // B2 uses the region endpoint for API calls (path-style) and virtual-hosted-style for public
+  // asset URLs, unless the user has configured a custom CDN `public_url`. B2’s S3-compatible API
+  // rejects the `public-read` canned ACL (objects inherit the bucket’s public/private setting), so
+  // `acl` is forced to `false` to suppress the `x-amz-acl` header that `core.js` sends by default.
+  return {
+    ...libOptions,
+    endpoint: `https://s3.${libOptions.region}.backblazeb2.com`,
+    public_url:
+      libOptions.public_url ??
+      `https://${libOptions.bucket}.s3.${libOptions.region}.backblazeb2.com`,
+    acl: false,
+  };
+};
+
+/**
+ * List files from Backblaze B2.
+ * @param {MediaLibraryFetchOptions} options Options containing the configuration.
+ * @returns {Promise<ExternalAsset[]>} Assets.
+ */
+export const list = async (options) => listS3Objects(getConfig(options), options);
+
+/**
+ * Search files in Backblaze B2.
+ * @param {string} query Search query.
+ * @param {MediaLibraryFetchOptions} options Options containing the configuration.
+ * @returns {Promise<ExternalAsset[]>} Assets.
+ */
+export const search = async (query, options) => searchS3Objects(query, getConfig(options), options);
+
+/**
+ * Upload files to Backblaze B2.
+ * @param {File[]} files Files to upload.
+ * @param {MediaLibraryFetchOptions} options Options containing the configuration.
+ * @returns {Promise<ExternalAsset[]>} Uploaded assets.
+ */
+export const upload = async (files, options) => uploadToS3(files, getConfig(options), options);
+
+/**
+ * Backblaze B2 media library service integration.
+ * @type {MediaLibraryService}
+ * @see https://www.backblaze.com/docs/cloud-storage-s3-compatible-api
+ * @see https://github.com/sveltia/sveltia-cms/issues/773
+ */
+export default {
+  serviceType: 'cloud_storage',
+  serviceId: 'backblaze_b2',
+  serviceLabel: 'Backblaze B2',
+  serviceURL: 'https://www.backblaze.com/cloud-storage',
+  showServiceLink: true,
+  hotlinking: true,
+  authType: 'api_key',
+  developerURL: 'https://www.backblaze.com/docs/cloud-storage-s3-compatible-api',
+  apiKeyURL: 'https://secure.backblaze.com/app_keys.htm',
+  apiKeyPattern: /^[A-Za-z0-9/+=]{31}$/,
+  isEnabled,
+  list,
+  search,
+  upload,
+};

--- a/src/lib/services/integrations/media-libraries/cloud/s3/backblaze-b2.test.js
+++ b/src/lib/services/integrations/media-libraries/cloud/s3/backblaze-b2.test.js
@@ -1,0 +1,301 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import backblazeB2Service, {
+  getLibraryOptions,
+  isEnabled,
+  list,
+  search,
+  upload,
+} from './backblaze-b2';
+
+// Mock dependencies
+vi.mock('svelte/store', () => ({
+  get: vi.fn(),
+}));
+
+vi.mock('$lib/services/config', () => ({
+  cmsConfig: { subscribe: vi.fn() },
+}));
+
+vi.mock('./index', () => ({
+  listS3Objects: vi.fn(),
+  searchS3Objects: vi.fn(),
+  uploadToS3: vi.fn(),
+}));
+
+vi.mock('./core', async (importOriginal) => {
+  const actual = /** @type {object} */ (await importOriginal());
+
+  return {
+    ...actual,
+    listS3Objects: vi.fn(),
+    searchS3Objects: vi.fn(),
+    uploadToS3: vi.fn(),
+  };
+});
+
+describe('integrations/media-libraries/cloud/s3/backblaze-b2', () => {
+  // A B2 application key ID (the S3 access key ID) is a 25-character string
+  const mockAccessKeyId = '0055f1a2b3c4d5e0000000001';
+  const mockBucket = 'my-bucket';
+  const mockRegion = 'us-east-005';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(get).mockReturnValue({
+      media_libraries: {
+        backblaze_b2: {
+          access_key_id: mockAccessKeyId,
+          bucket: mockBucket,
+          region: mockRegion,
+        },
+      },
+    });
+  });
+
+  describe('service configuration', () => {
+    it('should have correct service configuration', () => {
+      expect(backblazeB2Service.serviceType).toBe('cloud_storage');
+      expect(backblazeB2Service.serviceId).toBe('backblaze_b2');
+      expect(backblazeB2Service.serviceLabel).toBe('Backblaze B2');
+      expect(backblazeB2Service.serviceURL).toBe('https://www.backblaze.com/cloud-storage');
+      expect(backblazeB2Service.showServiceLink).toBe(true);
+      expect(backblazeB2Service.hotlinking).toBe(true);
+      expect(backblazeB2Service.authType).toBe('api_key');
+      expect(backblazeB2Service.developerURL).toBe(
+        'https://www.backblaze.com/docs/cloud-storage-s3-compatible-api',
+      );
+      expect(backblazeB2Service.apiKeyURL).toBe('https://secure.backblaze.com/app_keys.htm');
+      expect(backblazeB2Service.apiKeyPattern).toBeInstanceOf(RegExp);
+      // eslint-disable-next-line import-x/no-named-as-default-member
+      expect(backblazeB2Service.isEnabled).toBeDefined();
+    });
+
+    it('should validate application key format', () => {
+      const { apiKeyPattern } = backblazeB2Service;
+
+      if (!apiKeyPattern) {
+        throw new Error('apiKeyPattern is not defined');
+      }
+
+      // Valid B2 application keys are 31 base64 characters
+      expect(apiKeyPattern.test(`K005${'a'.repeat(27)}`)).toBe(true); // 31 chars
+      expect(apiKeyPattern.test(`${'A'.repeat(29)}/+`)).toBe(true); // 31 chars incl. / and +
+      expect(apiKeyPattern.test(`${'0123456789'.repeat(3)}a`)).toBe(true); // 31 chars
+
+      // Invalid application keys
+      expect(apiKeyPattern.test('a'.repeat(30))).toBe(false); // too short
+      expect(apiKeyPattern.test('a'.repeat(32))).toBe(false); // too long
+      expect(apiKeyPattern.test('a'.repeat(40))).toBe(false); // AWS-length, not B2
+      expect(apiKeyPattern.test(`${'a'.repeat(30)}-`)).toBe(false); // illegal char
+      expect(apiKeyPattern.test('')).toBe(false);
+    });
+  });
+
+  describe('isEnabled', () => {
+    it('should return true when valid config is present', () => {
+      expect(isEnabled()).toBe(true);
+    });
+
+    it('should return false when config is missing', () => {
+      vi.mocked(get).mockReturnValue({});
+
+      expect(isEnabled()).toBe(false);
+    });
+
+    it('should return false when credentials are missing', () => {
+      vi.mocked(get).mockReturnValue({
+        media_libraries: {
+          backblaze_b2: {},
+        },
+      });
+
+      expect(isEnabled()).toBe(false);
+    });
+
+    it('should return true when field-level config is present', () => {
+      vi.mocked(get).mockReturnValue({});
+
+      expect(
+        isEnabled(
+          /** @type {any} */ ({
+            widget: 'file',
+            media_libraries: {
+              backblaze_b2: {
+                access_key_id: mockAccessKeyId,
+                bucket: mockBucket,
+                region: mockRegion,
+              },
+            },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it('should return false when field-level config has missing credentials', () => {
+      vi.mocked(get).mockReturnValue({});
+
+      expect(
+        isEnabled(
+          /** @type {any} */ ({
+            widget: 'file',
+            media_libraries: {
+              backblaze_b2: {},
+            },
+          }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('getLibraryOptions', () => {
+    it('should return Backblaze B2 configuration', () => {
+      const options = getLibraryOptions();
+
+      expect(options).toEqual({
+        access_key_id: mockAccessKeyId,
+        bucket: mockBucket,
+        region: mockRegion,
+      });
+    });
+
+    it('should return config from legacy media_library format', () => {
+      vi.mocked(get).mockReturnValue({
+        media_library: {
+          name: 'backblaze_b2',
+          access_key_id: mockAccessKeyId,
+          bucket: mockBucket,
+          region: mockRegion,
+        },
+      });
+
+      const options = getLibraryOptions();
+
+      expect(options).toMatchObject({
+        name: 'backblaze_b2',
+        access_key_id: mockAccessKeyId,
+        bucket: mockBucket,
+        region: mockRegion,
+      });
+    });
+
+    it('should return undefined when neither media_libraries nor matching media_library exists', () => {
+      vi.mocked(get).mockReturnValue({
+        media_library: { name: 'other_service' },
+      });
+
+      expect(getLibraryOptions()).toBeUndefined();
+    });
+  });
+
+  describe('list/search/upload config building', () => {
+    const mockOptions = { kind: undefined, apiKey: 'secret', fieldConfig: undefined };
+
+    beforeEach(async () => {
+      const core = await import('./core');
+
+      vi.mocked(core.listS3Objects).mockResolvedValue([]);
+      vi.mocked(core.searchS3Objects).mockResolvedValue([]);
+      vi.mocked(core.uploadToS3).mockResolvedValue([]);
+    });
+
+    it('list should use path-style region endpoint, derive virtual-hosted public_url, force acl false', async () => {
+      const core = await import('./core');
+
+      await list(mockOptions);
+
+      expect(core.listS3Objects).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: `https://s3.${mockRegion}.backblazeb2.com`,
+          public_url: `https://${mockBucket}.s3.${mockRegion}.backblazeb2.com`,
+          acl: false,
+        }),
+        mockOptions,
+      );
+    });
+
+    it('list should use explicit public_url when set in config', async () => {
+      const core = await import('./core');
+
+      vi.mocked(get).mockReturnValue({
+        media_libraries: {
+          backblaze_b2: {
+            access_key_id: mockAccessKeyId,
+            bucket: mockBucket,
+            region: mockRegion,
+            public_url: 'https://my-cdn.example.com',
+          },
+        },
+      });
+
+      await list(mockOptions);
+
+      expect(core.listS3Objects).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: `https://s3.${mockRegion}.backblazeb2.com`,
+          public_url: 'https://my-cdn.example.com',
+          acl: false,
+        }),
+        mockOptions,
+      );
+    });
+
+    it('search should use path-style region endpoint and derive virtual-hosted public_url', async () => {
+      const core = await import('./core');
+
+      await search('photo', mockOptions);
+
+      expect(core.searchS3Objects).toHaveBeenCalledWith(
+        'photo',
+        expect.objectContaining({
+          endpoint: `https://s3.${mockRegion}.backblazeb2.com`,
+          public_url: `https://${mockBucket}.s3.${mockRegion}.backblazeb2.com`,
+          acl: false,
+        }),
+        mockOptions,
+      );
+    });
+
+    it('upload should use path-style region endpoint and derive virtual-hosted public_url', async () => {
+      const core = await import('./core');
+
+      await upload([], mockOptions);
+
+      expect(core.uploadToS3).toHaveBeenCalledWith(
+        [],
+        expect.objectContaining({
+          endpoint: `https://s3.${mockRegion}.backblazeb2.com`,
+          public_url: `https://${mockBucket}.s3.${mockRegion}.backblazeb2.com`,
+          acl: false,
+        }),
+        mockOptions,
+      );
+    });
+
+    it('list should reject when config is not available', async () => {
+      vi.mocked(get).mockReturnValue({});
+
+      await expect(
+        list({ kind: undefined, apiKey: 'secret', fieldConfig: undefined }),
+      ).rejects.toThrow('Backblaze B2 configuration is not available');
+    });
+
+    it('search should reject when config is not available', async () => {
+      vi.mocked(get).mockReturnValue({});
+
+      await expect(
+        search('photo', { kind: undefined, apiKey: 'secret', fieldConfig: undefined }),
+      ).rejects.toThrow('Backblaze B2 configuration is not available');
+    });
+
+    it('upload should reject when config is not available', async () => {
+      vi.mocked(get).mockReturnValue({});
+
+      await expect(upload([], { apiKey: 'secret', fieldConfig: undefined })).rejects.toThrow(
+        'Backblaze B2 configuration is not available',
+      );
+    });
+  });
+});

--- a/src/lib/types/public.js
+++ b/src/lib/types/public.js
@@ -31,7 +31,7 @@
 
 /**
  * Cloud media storage name.
- * @typedef {'cloudinary' | 'uploadcare' | 'aws_s3' | 'cloudflare_r2' |
+ * @typedef {'cloudinary' | 'uploadcare' | 'aws_s3' | 'backblaze_b2' | 'cloudflare_r2' |
  * 'digitalocean_spaces' | 'scaleway_object_storage' | 'supabase_storage'} CloudMediaLibraryName
  */
 
@@ -181,8 +181,8 @@
  * @property {string} [name] Media library name (used when configuring via legacy `media_library`).
  * @property {string} access_key_id AWS access key ID or equivalent (safe to store in config).
  * @property {string} bucket Bucket name.
- * @property {string} [region] AWS region (e.g., 'us-east-1'). Required for Amazon S3, DigitalOcean
- * Spaces, Scaleway Object Storage, and Supabase Storage.
+ * @property {string} [region] AWS region (e.g., 'us-east-1'). Required for Amazon S3, Backblaze B2
+ * (e.g., 'us-east-005'), DigitalOcean Spaces, Scaleway Object Storage, and Supabase Storage.
  * @property {string} [account_id] Cloudflare account ID. Required for Cloudflare R2.
  * @property {'default' | 'eu' | 'fedramp'} [jurisdiction] Cloudflare R2 jurisdiction. Required for
  * buckets created in the EU or FedRAMP jurisdictions; the global endpoint returns an error for
@@ -237,6 +237,8 @@
  * Set to `false` to explicitly disable.
  * @property {S3MediaLibrary | false} [aws_s3] Options for the Amazon S3 media storage. Set to
  * `false` to explicitly disable.
+ * @property {S3MediaLibrary | false} [backblaze_b2] Options for the Backblaze B2 media storage. Set
+ * to `false` to explicitly disable.
  * @property {S3MediaLibrary | false} [cloudflare_r2] Options for the Cloudflare R2 media storage.
  * Set to `false` to explicitly disable.
  * @property {S3MediaLibrary | false} [digitalocean_spaces] Options for the DigitalOcean Spaces


### PR DESCRIPTION
Related to https://github.com/sveltia/sveltia-cms/issues/773

Hi @kyoshino I tested on my site locally and all worked! 

<img width="2000" height="1047" alt="image" src="https://github.com/user-attachments/assets/e88e832b-f3c8-4791-b28a-75fef8bbb6dc" />

---

Prepared a docs for you. Feel free to edit as you prefer :) 

---

# Backblaze B2

## Overview

Backblaze B2 is an S3-compatible object storage service known for low-cost storage and free egress to its CDN and compute partners (Cloudflare, Fastly, Vultr, and others via the Bandwidth Alliance). Sveltia CMS enables direct browser-to-B2 uploads using AWS Signature Version 4, eliminating the need for backend infrastructure.

## Requirements

- An active Backblaze B2 account with a bucket
- A B2 **Application Key** (a key ID + application key pair)

> [!NOTE]
> Creating a **public** bucket requires a payment method on the account. On a brand-new account with no billing history, Backblaze returns `no_payment_history` when you try to make a bucket public. Add a payment method first if you need public (unsigned) asset URLs — see [Bucket Visibility](#bucket-visibility).

### Content Security Policy

If your site uses a Content Security Policy, you must allow the Backblaze endpoints. See [Content Security Policy](#content-security-policy) below.

## Setup

### Obtaining Credentials

Create an Application Key under **Account → Application Keys** ([secure.backblaze.com/app_keys.htm](https://secure.backblaze.com/app_keys.htm)).

We recommend a **bucket-scoped** key (restrict it to the single bucket you’ll use) rather than your master key, because the key ID is stored in your public CMS config. Grant these capabilities:

- `listBuckets`, `listFiles` — browse the media library
- `readFiles` — preview and download
- `writeFiles` — upload
- `deleteFiles` — delete

The resulting **key ID** (`applicationKeyId`, a 25-character string such as `0055f1a2b3c4d5e0000000001`) is your `access_key_id` and is safe to store in config. The **application key** (a 31-character secret) is the S3 Secret Access Key — users enter it in the CMS UI the first time they open the media library, and it is **never** stored in config.

### Determining Your Region

B2 buckets are region-locked. Your region is shown in the Backblaze console on the bucket detail page as the **Endpoint**, e.g. `s3.us-east-005.backblazeb2.com` → region `us-east-005`. Common regions:

| Region | S3 endpoint |
| --- | --- |
| `us-west-001` | `s3.us-west-001.backblazeb2.com` |
| `us-west-002` | `s3.us-west-002.backblazeb2.com` |
| `us-west-004` | `s3.us-west-004.backblazeb2.com` |
| `us-east-005` | `s3.us-east-005.backblazeb2.com` |
| `eu-central-003` | `s3.eu-central-003.backblazeb2.com` |

### Bucket Visibility

Asset previews and downloads use unsigned, direct URLs, so the bucket must allow public reads:

- Set the bucket to **Public** in the Backblaze console (Bucket Settings → *Files in bucket are: Public*).
- Backblaze’s S3 endpoint serves objects in a public bucket **anonymously**, so the default asset URL — `https://{bucket}.s3.{region}.backblazeb2.com/{key}` — works with **no `public_url` needed**. (This differs from Cloudflare R2, whose S3 endpoint always requires authentication and therefore mandates a separate public URL.)
- For a **private** bucket, set `public_url` to a CDN or custom domain placed in front of the bucket (e.g. Cloudflare). The private S3 URL requires signing and cannot be used directly in an `<img>` tag.

### CORS Configuration

Sveltia CMS sends custom AWS Signature v4 headers (`Authorization`, `x-amz-date`, `x-amz-content-sha256`), which make the browser issue a CORS preflight on every request — including the `ListObjectsV2` call used to browse the bucket. The bucket must return matching CORS headers or the browser blocks the request with:

```
Access to fetch at 'https://s3.{region}.backblazeb2.com/{bucket}?list-type=2…'
from origin 'https://your-cms-domain.com' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

> [!IMPORTANT]
> **Do not use the Backblaze web console’s “Share everything in this bucket with all origins” preset.** That preset writes *native* download-only rules (`b2_download_file_by_name` / `b2_download_file_by_id`) which do **not** authorize the S3 `ListObjectsV2` (bucket-level GET), `PutObject`, or `DeleteObject` requests the CMS makes — so browsing and uploading still fail. Configure CORS with the explicit operations/methods below.

B2 stores CORS rules in an operation-based format, but its S3 API maps those operations to standard HTTP methods at request time. A complete rule for Sveltia must cover all of:

| B2 native operation | S3 method | Used by the CMS for |
| --- | --- | --- |
| `s3_get` | `GET` | downloads **and** `ListObjectsV2` (browsing) |
| `s3_head` | `HEAD` | object metadata |
| `s3_put` | `PUT` | uploads |
| `s3_delete` | `DELETE` | deletions |
| `s3_post` | `POST` | multipart uploads / batch delete |

…and it must allow the Signature v4 request headers (`allowedHeaders: ["*"]` is simplest).

**Option A — Backblaze CLI (recommended):**

```sh
b2 account authorize <keyID> <applicationKey>
b2 bucket update --cors-rules '[
  {
    "corsRuleName": "sveltia-cms",
    "allowedOrigins": ["https://your-cms-domain.com"],
    "allowedOperations": ["s3_get", "s3_head", "s3_put", "s3_delete", "s3_post"],
    "allowedHeaders": ["*"],
    "exposeHeaders": ["ETag", "x-amz-request-id"],
    "maxAgeSeconds": 3600
  }
]' <bucket-name> allPublic
```

**Option B — AWS CLI (`s3api`):** B2’s S3 API also implements `GetBucketCors` / `PutBucketCors`, and translates the standard S3 methods to/from its native operations, so an AWS-style policy works too:

```json
[
  {
    "AllowedHeaders": ["*"],
    "AllowedMethods": ["GET", "PUT", "HEAD", "DELETE", "POST"],
    "AllowedOrigins": ["https://your-cms-domain.com"],
    "ExposeHeaders": ["ETag"],
    "MaxAgeSeconds": 3000
  }
]
```

```sh
aws s3api put-bucket-cors --bucket <bucket-name> \
  --endpoint-url https://s3.{region}.backblazeb2.com \
  --cors-configuration file://cors.json
```

For local development, add your dev origin to `allowedOrigins` (e.g. `http://localhost:5173`).

## Configuration Example

```yaml
media_libraries:
  backblaze_b2:
    access_key_id: 0055f1a2b3c4d5e0000000001
    bucket: my-bucket
    region: us-east-005
    prefix: cms-uploads/
    # public_url is OPTIONAL for B2:
    # - Omit it for a PUBLIC bucket — assets are served anonymously at
    #   https://my-bucket.s3.us-east-005.backblazeb2.com/{key}
    # - Set it for a PRIVATE bucket fronted by a CDN/custom domain:
    # public_url: https://my-cdn.example.com
```

## Configuration Properties

| Property | Required | Purpose |
| --- | --- | --- |
| `access_key_id` | Yes | B2 Application Key ID (the S3 access key ID; safe for config) |
| `bucket` | Yes | Bucket name |
| `region` | Yes | B2 region code, e.g. `us-east-005`, `us-west-004`, `eu-central-003` |
| `prefix` | No | Path prefix within the bucket, e.g. `uploads/` |
| `public_url` | No | CDN/custom-domain base URL. Optional for public buckets (the default S3 URL is served anonymously); required for private buckets |

> [!NOTE]
> **Object ACLs.** B2’s S3 API rejects the `public-read` canned ACL (`Unsupported value for canned acl 'public-read'`); object visibility is controlled at the bucket level instead. The Backblaze B2 integration handles this automatically — it omits the `x-amz-acl` header on uploads, so objects inherit the bucket’s public/private setting. No configuration is required.

## Content Security Policy

API calls go to `https://s3.{region}.backblazeb2.com`; asset URLs use `https://{bucket}.s3.{region}.backblazeb2.com` by default:

```
connect-src https://s3.us-east-005.backblazeb2.com;
img-src     https://my-bucket.s3.us-east-005.backblazeb2.com;
```

When serving assets through a CDN or custom domain via `public_url`:

```
connect-src https://s3.us-east-005.backblazeb2.com;
img-src     https://my-cdn.example.com;
```

## Usage

Access Backblaze B2 through File and Image fields in Sveltia CMS. Select **Backblaze B2** under *External Locations* in the asset picker, then enter your application key (the Secret Access Key) when first accessing the media library to browse, upload, and select assets.

