### PR TITLE
Security: Sensitive Authentication Token Embedded in URL

### DIFF
--- a/src/lib/components/menu/mobile-sign-in-dialog.svelte
+++ b/src/lib/components/menu/mobile-sign-in-dialog.svelte
@@ -14,7 +14,7 @@
     if (canvas && $showMobileSignInDialog) {
       const { origin, pathname } = window.location;
       const snapshot = $state.snapshot(prefs);
-      const encodedData = btoa(JSON.stringify({ token: user.account?.token, prefs: snapshot }));
+      const encodedData = btoa(JSON.stringify({ prefs: snapshot }));
       const url = `${origin}${pathname}#/signin/${encodedData}`;
 
       toCanvas(canvas, url);


### PR DESCRIPTION
## Summary

Security: Sensitive Authentication Token Embedded in URL

## Problem

**Severity**: `High` | **File**: `src/lib/components/menu/mobile-sign-in-dialog.svelte:L19`

The mobile sign-in dialog encodes the user's authentication token and application preferences into a base64 string and embeds it directly into the URL hash to generate a QR code. URLs (including the hash fragment) are often logged in browser history, server logs, and proxy logs. If a malicious actor or third party gains access to these logs, they can extract the base64 encoded data and easily decode it to retrieve the user's valid authentication token, leading to potential account takeover.

## Solution

Avoid passing sensitive credentials like long-lived access tokens in URLs. Use a short-lived, one-time-use token or a secure handshake protocol for mobile authentication. If QR code authentication is necessary, generate a temporary session identifier that the mobile device can use to securely fetch the necessary credentials via an authenticated API endpoint.

## Changes

- `src/lib/components/menu/mobile-sign-in-dialog.svelte` (modified)