### PR TITLE
Add tests validating locale file integrity

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "eslint-plugin-svelte": "^3.22.0",
     "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^17.9.0",
+    "messageformat": "^4.0.0",
     "oxlint": "^1.77.0",
     "postcss-html": "^2.0.0",
     "prettier": "^3.9.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       globals:
         specifier: ^17.9.0
         version: 17.9.0
+      messageformat:
+        specifier: ^4.0.0
+        version: 4.0.0
       oxlint:
         specifier: ^1.77.0
         version: 1.77.0

--- a/src/lib/locales/locales.test.js
+++ b/src/lib/locales/locales.test.js
@@ -1,0 +1,147 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { MessageFormat } from 'messageformat';
+import { describe, expect, test } from 'vitest';
+import YAML from 'yaml';
+
+/**
+ * Locale file used as the source of truth for keys and variables.
+ */
+const SOURCE_LOCALE = 'en-US';
+/**
+ * Counts used to exercise every plural category, including the `zero`, `two`, `few` and `many`
+ * forms that languages such as Arabic, Polish and Russian rely on.
+ */
+const SAMPLE_COUNTS = [0, 1, 2, 3, 11, 100];
+const localesDir = import.meta.dirname;
+
+/**
+ * Read and parse a locale file.
+ * @param {string} fileName Locale file name, e.g. `ja.yaml`.
+ * @returns {Record<string, any>} Parsed strings.
+ */
+const readLocale = (fileName) =>
+  YAML.parse(fs.readFileSync(path.join(localesDir, fileName), 'utf8'));
+
+/**
+ * Flatten a nested string map into dot-notation keys.
+ * @param {Record<string, any>} obj Parsed locale strings.
+ * @param {string} [prefix] Key prefix used while recursing.
+ * @returns {Map<string, string>} Flattened strings, keyed with the full key path.
+ */
+const flatten = (obj, prefix = '') =>
+  new Map(
+    Object.entries(obj).flatMap(([key, value]) =>
+      value && typeof value === 'object'
+        ? [...flatten(value, `${prefix}${key}.`)]
+        : [[`${prefix}${key}`, String(value)]],
+    ),
+  );
+
+/**
+ * Get every variable a message refers to, including the `.input` and `.match` declarations that
+ * drive plural selection.
+ * @param {string} message MessageFormat 2 message.
+ * @returns {Set<string>} Variable names without the `$` sigil.
+ */
+const getDeclaredVariables = (message) =>
+  new Set([...message.matchAll(/\$([A-Za-z]+)/g)].map(([, name]) => name));
+
+/**
+ * Get the variables a message interpolates into its output, ignoring declarations.
+ * @param {string} message MessageFormat 2 message.
+ * @returns {Set<string>} Variable names without the `$` sigil.
+ */
+const getUsedVariables = (message) =>
+  new Set([...message.matchAll(/\{\$([A-Za-z]+)\}/g)].map(([, name]) => name));
+
+/**
+ * Build arguments for {@link MessageFormat.format}, matching each variable’s declared type.
+ * @param {string} message MessageFormat 2 message.
+ * @param {number} count Value used for numeric variables.
+ * @returns {Record<string, string | number>} Formatting arguments.
+ */
+const getSampleArgs = (message, count) =>
+  Object.fromEntries(
+    [...getDeclaredVariables(message)].map((name) => [
+      name,
+      message.includes(`{$${name} :integer}`) ? count : 'sample',
+    ]),
+  );
+
+const sourceStrings = flatten(readLocale(`${SOURCE_LOCALE}.yaml`));
+
+const localeFiles = fs
+  .readdirSync(localesDir)
+  .filter((fileName) => fileName.endsWith('.yaml'))
+  .sort();
+
+const translationFiles = localeFiles.filter((fileName) => fileName !== `${SOURCE_LOCALE}.yaml`);
+
+describe('locale files', () => {
+  test('the source locale is present and not empty', () => {
+    expect(localeFiles).toContain(`${SOURCE_LOCALE}.yaml`);
+    expect(sourceStrings.size).toBeGreaterThan(0);
+  });
+
+  describe.each(localeFiles)('%s', (fileName) => {
+    const locale = fileName.replace(/\.yaml$/, '');
+    const strings = flatten(readLocale(fileName));
+
+    test('every message compiles and formats as MessageFormat 2', () => {
+      /** @type {string[]} */
+      const errors = [];
+
+      strings.forEach((message, key) => {
+        SAMPLE_COUNTS.forEach((count) => {
+          try {
+            new MessageFormat(locale, message).format(getSampleArgs(message, count), (error) => {
+              throw error;
+            });
+          } catch (/** @type {any} */ error) {
+            errors.push(`${key} (count: ${count}): ${error.message}`);
+          }
+        });
+      });
+
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe.each(translationFiles)('%s', (fileName) => {
+    const strings = flatten(readLocale(fileName));
+
+    test(`has no keys that are gone from ${SOURCE_LOCALE}`, () => {
+      const staleKeys = [...strings.keys()].filter((key) => !sourceStrings.has(key));
+
+      expect(staleKeys).toEqual([]);
+    });
+
+    test('only interpolates variables the source message provides', () => {
+      /** @type {string[]} */
+      const errors = [];
+
+      strings.forEach((message, key) => {
+        const sourceMessage = sourceStrings.get(key);
+
+        if (sourceMessage === undefined) {
+          return;
+        }
+
+        const available = getDeclaredVariables(sourceMessage);
+
+        // A translation may interpolate a variable the source only selects on — Arabic, for
+        // example, spells out the count in plural forms English doesn’t have — but it can never
+        // introduce one the source doesn’t provide.
+        [...getUsedVariables(message)]
+          .filter((name) => !available.has(name))
+          .forEach((name) => {
+            errors.push(`${key}: $${name}`);
+          });
+      });
+
+      expect(errors).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Nothing currently validates the contents of the locale files. `i18n.test.js` mocks them away, `check:cspell` skips `src/lib/locales/*.yaml`, and Prettier only sees formatting. I confirmed the gap by renaming `{$collection}` to `{$collectie}` in a locale file and breaking a plural variant: `pnpm check` and all 7252 tests stayed green. A mistake like that reaches users as a literal `{$collectie}` in the UI, or as a silently mis-selected plural.

This adds `src/lib/locales/locales.test.js`, which asserts for every locale file that:

1. **every message compiles and formats as MessageFormat 2**, exercised at counts 0, 1, 2, 3, 11 and 100 so `zero` / `two` / `few` / `many` variants are actually reached;
2. **translations carry no keys that are gone from `en-US`**, catching leftovers after an upstream rename;
3. **translations never interpolate a variable the source message doesn't provide**.

Two deliberate design choices, both driven by what the existing locales actually do:

- **Missing keys are allowed.** Twelve of the fourteen translations currently lag two to six strings behind `en-US`, which is normal between sync rounds. Failing CI on that would punish translators for the project's own release cadence, so only *stale* keys are an error.
- **Variables are checked as a subset, not for equality.** A translation may legitimately interpolate a variable the English only selects on — `ar.yaml` spells out `{$count}` in the `few` and `many` forms of `entry_parse_errors`, where English needs no number at all. Requiring identical variables would fail 16 correct Arabic strings. Introducing a variable the source doesn't provide is still an error.

All fourteen existing locales pass unchanged; no translation files are touched.

I checked that the test actually fails when it should, by mutating real locale files one at a time and reverting each:

| mutation | result |
| --- | --- |
| `{$collection}` → `{$collectie}` in `ja.yaml` | fails: `x_collection: $collectie` |
| added `{$bogus}` to a string in `ru.yaml` | fails: `no_results: $bogus` |
| removed a `.match` line in `pl.yaml` | fails: message no longer compiles |
| appended an obsolete key to `tr.yaml` | fails: stale key |

`messageformat` is added as a devDependency. It is already in the tree as a dependency of `@sveltia/i18n` at the same version, so nothing new is downloaded and the bundle is unaffected — the test just can't resolve it through pnpm's strict layout without an explicit entry.
