### PR TITLE
Add Korean localization

### DIFF
--- a/src/lib/locales/ko.yaml
+++ b/src/lib/locales/ko.yaml
@@ -1,0 +1,1688 @@
+# Read https://github.com/sveltia/sveltia-cms/blob/main/src/lib/locales/README.md
+# for instructions on how to add new languages or update existing translations.
+
+# ==============================================================================
+# Common Actions
+# ==============================================================================
+# Generic action button labels used throughout the application. These are
+# reusable strings for common operations like save, delete, cancel, etc.
+
+# Primary actions: creation, selection, and file operations
+create: 새로 만들기
+select: 선택
+select_all: 전체 선택
+upload: 업로드
+copy: 복사
+download: 다운로드
+duplicate: 복제
+delete: 삭제
+reorder: 순서 변경
+
+# Dialog and form actions: confirmation and cancellation
+cancel: 취소
+done: 완료
+save: 저장
+# Progress indicator shown on the save button while a save operation is in progress
+saving: 저장 중…
+
+# Publishing actions: used when committing changes to the repository
+publish: 게시
+# Progress indicator shown on the publish button during publishing
+publishing: 게시 중…
+
+# Modification actions: editing and updating content
+rename: 이름 변경
+update: 업데이트
+replace: 교체
+
+# List and collection actions: adding and removing items
+add: 추가
+remove: 제거
+clear: 지우기
+
+# Expansion and collapse actions: used for accordions, trees, and expandable sections
+expand: 펼치기
+expand_all: 모두 펼치기
+collapse: 접기
+collapse_all: 모두 접기
+
+# Content manipulation: inserting, restoring, and discarding
+insert: 삽입
+restore: 복원
+discard: 버리기
+
+# ==============================================================================
+# Common UI Elements
+# ==============================================================================
+# Reusable labels and messages for common interface elements like status
+# indicators, loading states, and toolbar regions.
+
+# Status messages: search and results indicators
+# Shown in ARIA live regions during search operations
+searching: 검색 중…
+no_results: 검색 결과가 없습니다.
+
+# Toolbar region labels: used as aria-labels for different toolbar areas
+# These help screen readers identify which toolbar is being navigated
+global: 전역
+primary: 기본
+secondary: 보조
+collection: 컬렉션
+folder: 폴더
+
+# ==============================================================================
+# Miscellaneous Labels
+# ==============================================================================
+# Various labels used across the application for specific UI elements
+# that don’t fit into other categories.
+
+# Field and input labels
+api_key: API 키
+details: 세부 정보
+back: 뒤로
+# Loading indicator shown during async operations (asset preview, panels, etc.)
+loading: 불러오는 중…
+# Dismiss button for temporary notifications and infobars
+later: 나중에
+
+# Entry and collection labels
+# Slug field heading in entry editors
+slug: 슬러그
+# Fallback labels for singleton collections when names aren’t configured
+singleton: 싱글턴
+singletons: 싱글턴
+
+# Error messages
+# Toast notification when clipboard operations fail
+clipboard_error: 클립보드에 복사하지 못했습니다.
+
+# ==============================================================================
+# Sign-In Page
+# ==============================================================================
+# Strings specific to the authentication and sign-in page, including welcome
+# messages, loading states, OAuth flows, and repository access options.
+
+# Welcome and branding
+# Screen reader announcement when the sign-in page loads
+# {$name} is the app title shown on the sign-in screen, Sveltia CMS by default
+welcome_message: '{$name}에 오신 것을 환영합니다'
+# Footer text with CMS branding
+# {$name} is the CMS brand name shown in the footer, Sveltia CMS by default
+powered_by: 'Powered by {$name}'
+
+# Shown during initial configuration and data loading
+loading_cms_config: CMS 설정을 불러오는 중…
+loading_site_data: 사이트 데이터를 불러오는 중…
+loading_site_data_error: 사이트 데이터를 불러오는 중 오류가 발생했습니다.
+
+# OAuth and token authentication
+# Primary sign-in button label for OAuth providers (GitHub, GitLab, etc.)
+# {$service} is the sign-in provider label, such as GitHub or GitLab
+sign_in_with_x: '{$service}(으)로 로그인'
+
+# Access token dialog: alternative authentication method
+sign_in_using_access_token: 액세스 토큰으로 로그인
+sign_in_using_access_token_description: 아래에 토큰을 입력하십시오. 저장소 콘텐츠에 대한 읽기/쓰기 권한이 있어야 합니다.
+# Inline link text with embedded HTML anchor tag
+# {$service} is the provider name whose user settings page contains the token generator, e.g., GitHub or GitLab
+sign_in_using_access_token_link: <a>{$service} 사용자 설정 페이지</a>에서 토큰을 생성할 수 있습니다.
+# Input field label for personal access token
+personal_access_token: 개인용 액세스 토큰
+
+# Authentication progress indicators
+authorizing: 인증하는 중…
+signing_in: 로그인하는 중…
+
+# Local and test repository options
+# Button label and description for working with a local Git repository
+work_with_local_repo: 로컬 저장소로 작업
+# {$repo} is the configured repository name shown when it is available
+work_with_local_repo_description: 창이 표시되면 “{$repo}” 저장소의 루트 디렉터리를 선택하십시오.
+work_with_local_repo_description_no_repo: 창이 표시되면 사용하시는 Git 저장소의 루트 디렉터리를 선택하십시오.
+# Button label for demo/test repository
+work_with_test_repo: 테스트 저장소로 작업
+
+# Authentication errors
+# Error messages shown during sign-in failures
+sign_in_error:
+  not_project_root: 선택하신 폴더는 저장소 루트 디렉터리가 아닙니다. 다시 시도하십시오.
+  picker_dismissed: 저장소 루트 디렉터리를 선택하지 못했습니다. 다시 시도하십시오.
+  authentication_aborted: 인증이 중단되었습니다. 다시 시도하십시오.
+  invalid_token: 입력하신 토큰이 유효하지 않습니다. 확인 후 다시 시도하십시오.
+  # OAuth and authenticator errors (shown with error codes) — keys are defined in the Sveltia CMS Authenticator library
+  UNSUPPORTED_BACKEND: 사용 중이신 Git 백엔드는 인증기에서 지원되지 않습니다.
+  UNSUPPORTED_DOMAIN: 사용 중이신 도메인에서는 인증기를 사용할 수 없습니다.
+  MISCONFIGURED_CLIENT: OAuth 앱 클라이언트 ID 또는 시크릿이 설정되지 않았습니다.
+  AUTH_CODE_REQUEST_FAILED: 인증 코드를 받지 못했습니다. 나중에 다시 시도하십시오.
+  CSRF_DETECTED: CSRF 공격 가능성이 감지되어 인증 절차가 중단되었습니다.
+  TOKEN_REQUEST_FAILED: 액세스 토큰을 요청하지 못했습니다. 나중에 다시 시도하십시오.
+  TOKEN_REFRESH_FAILED: 액세스 토큰을 갱신하지 못했습니다. 나중에 다시 시도하십시오.
+  MALFORMED_RESPONSE: 서버가 잘못된 형식의 데이터를 반환했습니다. 나중에 다시 시도하십시오.
+
+# Backend and repository validation errors
+# Shown when the configured backend or repository is invalid or inaccessible
+# {$name} is the backend display name like Forgejo and {$version} is the minimum supported version
+backend_unsupported_version: '{$name} 백엔드에는 {$name} {$version} 이상이 필요합니다.'
+# {$repo} is the repository identifier, typically in owner/repo format
+repository_no_access: “{$repo}” 저장소에 접근할 권한이 없습니다.
+repository_not_found: “{$repo}” 저장소가 존재하지 않습니다.
+repository_empty: “{$repo}” 저장소에 브랜치가 없습니다.
+# {$repo} is the repository identifier, and {$branch} is the configured branch name
+branch_not_found: “{$repo}” 저장소에 “{$branch}” 브랜치가 없습니다.
+
+# General errors
+# Fallback error dialog title for unexpected errors
+unexpected_error: 예기치 않은 오류
+
+# Entry file parsing errors
+# Toast notification when entry files fail to parse on initial load
+# {$count} is the number of entry files that failed to parse
+entry_parse_errors: |
+  엔트리 파일을 구문 분석하는 중 오류가 발생했습니다. 자세한 내용은 브라우저 콘솔을 확인하십시오.
+
+# ==============================================================================
+# Authentication and Account
+# ==============================================================================
+# These strings are used for sign-in, account management, and authentication
+# flows throughout the application.
+
+# Sign-in page and external assets panel: credential input field aria-labels
+username: 사용자 이름
+password: 비밀번호
+
+# Sign-in actions: primary button labels and account menu items
+# Used on the sign-in page and in confirmation dialogs for external assets
+sign_in: 로그인
+
+# Mobile sign-in feature: dialog title and instructions for QR code authentication
+sign_in_with_mobile: 모바일로 로그인
+# Instructions shown in the mobile sign-in dialog for passwordless authentication
+sign_in_with_mobile_instruction: 비밀번호 없이 로그인하시려면 휴대전화나 태블릿으로 아래 QR 코드를 스캔하십시오. 설정이 자동으로 복사됩니다.
+
+# Account menu: user status and repository mode indicators
+# Shown at the top of the account dropdown menu
+# {$name} is the signed-in user’s login name
+signed_in_as_x: '{$name}(으)로 로그인됨'
+working_with_local_repo: 로컬 저장소로 작업 중
+working_with_test_repo: 테스트 저장소로 작업 중
+
+# Account menu: action items for sign-out and app installation
+sign_out: 로그아웃
+install_as_app: 앱으로 설치
+
+# ==============================================================================
+# Global Toolbar
+# ==============================================================================
+# Strings used in the main application toolbar, including navigation, search,
+# notifications, and menu items.
+
+# Main page titles in the global navigation and page switcher button group
+contents: 콘텐츠
+assets: 에셋
+editorial_workflow: 편집 워크플로
+cms_config: CMS 설정
+# Mobile menu page title (shown only on small screens)
+menu: 메뉴
+
+# Mobile promo infobar: encouraging users to try the mobile version
+mobile_promo_title: 이제 Sveltia CMS를 모바일에서도 사용할 수 있습니다!
+mobile_promo_button: 사용해 보기
+
+# New language infobar: encouraging users to switch to a newly available language
+# {$locale} is the localized language name, e.g., “French”
+new_language_available: 이제 Sveltia CMS를 {$locale}(으)로 사용할 수 있습니다!
+change_language: 언어 변경
+
+# Toast notification shown while the translation for the selected language is being downloaded
+# {$locale} is the localized language name, e.g., “French”
+switching_language: '{$locale}(으)로 전환하는 중…'
+locale_load_failed: '{$locale} 번역을 불러오지 못했습니다. 나중에 다시 시도하십시오.'
+
+# Site and page navigation
+# Toolbar button aria-label for visiting the live site
+visit_live_site: 라이브 사이트 방문
+# Page switcher button group aria-label for switching between main sections
+switch_page: 페이지 전환
+
+# Search input placeholders
+search_placeholder_contents: 콘텐츠 검색…
+search_placeholder_assets: 에셋 검색…
+search_placeholder_all: 콘텐츠 및 에셋 검색…
+
+# Create button: aria-label for the create menu in the toolbar
+create_entry_or_assets: 엔트리 또는 에셋 만들기
+
+# Publishing actions: button labels and progress indicators
+publish_changes: 변경 사항 게시
+publishing_changes: 변경 사항을 게시하는 중…
+# Error notification when publishing fails
+publishing_changes_failed: 변경 사항을 게시하지 못했습니다. 다시 시도하십시오.
+
+# Notifications: button aria-labels and section headings
+show_notifications: 알림 표시
+notifications: 알림
+
+# Account menu: button aria-labels and section headings
+show_account_menu: 계정 메뉴 표시
+# Account section heading in the account menu and mobile menu page
+account: 계정
+
+# Account menu items: links to external resources
+live_site: 라이브 사이트
+git_repository: Git 저장소
+settings: 설정
+
+# Help menu: button aria-labels and section headings
+show_help_menu: 도움말 메뉴 표시
+# Help section heading in dropdowns and mobile menu
+help: 도움말
+
+# Help menu items: documentation and support resources
+keyboard_shortcuts: 키보드 단축키
+documentation: 문서
+release_notes: 릴리스 노트
+announcements: 공지 사항
+# Version badge aria-label in the release notes menu item
+# {$version} is the current app version string
+version_x: '버전 {$version}'
+# Additional help menu items
+report_issue: 문제 신고
+share_feedback: 피드백 보내기
+get_help: 도움 받기
+donate: 후원하기
+join_discord: Discord에서 만나기
+bluesky: Bluesky에서 팔로우하기
+
+# Update notification: infobar message and button
+update_available: Sveltia CMS의 최신 버전을 사용할 수 있습니다.
+update_now: 지금 업데이트
+
+# Backend status notifications
+# Shown when the Git backend (GitHub, GitLab, etc.) is experiencing issues
+# {$service} is the backend service label shown in the toolbar notice, e.g., GitHub or GitLab
+backend_status:
+  minor_incident: '{$service}에 일부 장애가 발생했습니다. 작업에 영향이 있을 수 있습니다.'
+  major_incident: '{$service}에 심각한 장애가 발생했습니다. 상황이 개선될 때까지 기다리시는 것이 좋습니다.'
+
+# ==============================================================================
+# Content and Asset Libraries
+# ==============================================================================
+# Strings used in the main content and asset management interfaces, including
+# lists, navigation, and collection/folder views.
+
+# Page container aria-labels
+content_library: 콘텐츠 라이브러리
+asset_library: 에셋 라이브러리
+
+# Primary sidebar section headings and list aria-labels
+collections: 컬렉션
+entries: 엔트리
+files: 파일
+
+# Asset location selector: option group labels
+asset_location:
+  # Assets stored in the site’s Git repository
+  repository: 내 사이트
+  external: 외부 위치
+  stock_photos: 스톡 사진
+
+# Sidebar and list labels
+# Collection assets panel aria-label
+collection_assets: 컬렉션 에셋
+# List aria-labels for different list types
+entry_list: 엔트리 목록
+file_list: 파일 목록
+asset_list: 에셋 목록
+
+# Collection and folder page titles
+# Used as aria-labels on page containers
+# {$collection} is the current collection label
+x_collection: “{$collection}” 컬렉션
+# {$folder} is the current asset folder label
+x_asset_folder: “{$folder}” 에셋 폴더
+
+# Navigation announcements (ARIA live regions)
+# Announce page changes for screen reader users
+viewing_collection_list: 컬렉션 목록을 표시하고 있습니다.
+viewing_asset_folder_list: 에셋 폴더 목록을 표시하고 있습니다.
+# Collection view announcements with entry counts
+# {$collection} is the collection label and {$count} is the number of entries in it
+viewing_x_collection: |
+  .input {$count :integer}
+  .match $count
+    0   {{ “{$collection}” 컬렉션을 표시하고 있습니다. 아직 엔트리가 없습니다. }}
+    *   {{ “{$collection}” 컬렉션을 표시하고 있습니다. 엔트리가 {$count}개 있습니다. }}
+# Asset folder view announcements with asset counts
+# {$folder} is the folder label and {$count} is the number of assets in it
+viewing_x_asset_folder: |
+  .input {$count :integer}
+  .match $count
+    0   {{ “{$folder}” 에셋 폴더를 표시하고 있습니다. 아직 에셋이 없습니다. }}
+    *   {{ “{$folder}” 에셋 폴더를 표시하고 있습니다. 에셋이 {$count}개 있습니다. }}
+
+# Singleton file selection announcement
+# {$file} is the singleton file name
+singleton_selected_announcement: “{$file}” 파일을 편집하시려면 Enter 키를 누르십시오.
+
+# Error messages: collection or file not found
+collection_not_found: 컬렉션을 찾을 수 없습니다.
+file_not_found: 파일을 찾을 수 없습니다.
+
+# Selection count indicator
+# Shown in the toolbar when items are selected (e.g., “2 of 10 selected”)
+# {$selected} is the selected item count and {$total} is the total item count
+x_of_x_selected: '{$total}개 중 {$selected}개 선택됨'
+
+# View switcher: toggle between list and grid views
+switch_view: 보기 전환
+list_view: 목록 보기
+grid_view: 그리드 보기
+switch_to_list_view: 목록 보기로 전환
+switch_to_grid_view: 그리드 보기로 전환
+
+# ==============================================================================
+# List Controls: Sort, Filter, and Group
+# ==============================================================================
+# Strings for sorting, filtering, and grouping entries and assets in lists.
+
+# Sort menu: button labels and options
+sort: 정렬
+sorting_options: 정렬 옵션
+# Sort key option labels
+sort_keys:
+  # No sorting; entries appear in their natural repository order
+  none: 없음
+  name: 이름
+  slug: 슬러그
+  # Sort by the last commit’s author name
+  commit_author: 업데이트한 사람
+  # Sort by the last commit date
+  commit_date: 업데이트 날짜
+  # Sort by the entry’s computed summary text
+  _summary: 요약
+  # Manual order defined by the user via drag-and-drop
+  _manual: 수동
+# Sort order labels used with field names
+# Example: “Name, A to Z” or “Updated on, new to old”
+# {$label} is the localized sort field label
+ascending: '{$label} (A–Z)'
+ascending_date: '{$label} (오래된 순)'
+descending: '{$label} (Z–A)'
+descending_date: '{$label} (최신 순)'
+
+# Filter menu: button labels and options
+filter: 필터
+filtering_options: 필터 옵션
+
+# Group menu: button labels and options
+group: 그룹
+grouping_options: 그룹 옵션
+
+# Asset type filter and group labels
+type: 유형
+all: 전체
+# Asset type labels
+image: 이미지
+video: 동영상
+audio: 오디오
+document: 문서
+other: 기타
+
+# Toolbar toggles: show/hide panels
+show_assets: 에셋 표시
+hide_assets: 에셋 숨기기
+show_info: 정보 표시
+hide_info: 정보 숨기기
+
+# Folder display labels when no specific path is configured
+all_assets: 전체 에셋
+global_assets: 전역 에셋
+
+# ==============================================================================
+# Entry and Collection Actions
+# ==============================================================================
+# Strings related to creating, editing, and managing entries and collections.
+
+# Error message when entry cannot be found
+entry_not_found: 엔트리를 찾을 수 없습니다.
+
+# Entry creation restrictions: tooltip and advisory messages
+creating_entries_disabled_by_admin: 이 컬렉션에서는 관리자가 새 엔트리 만들기를 비활성화했습니다.
+# {$quota} is the collection’s maximum entry count
+creating_entries_disabled_by_quota: 이 컬렉션은 엔트리 {$quota}개 한도에 도달하여 새 엔트리를 추가할 수 없습니다.
+# {$quota} is the collection limit and {$remaining} is the number of entries that can still be created
+creating_entries_nearing_quota: |
+  .input {$remaining :integer}
+  .match $remaining
+    *   {{ 이 컬렉션이 엔트리 {$quota}개 한도에 근접했습니다. 엔트리를 {$remaining}개만 더 만들 수 있습니다. }}
+
+# Navigation: back links and list labels
+back_to_collection: 컬렉션으로 돌아가기
+collection_list: 컬렉션 목록
+back_to_collection_list: 컬렉션 목록으로 돌아가기
+asset_folder_list: 에셋 폴더 목록
+back_to_asset_folder_list: 에셋 폴더 목록으로 돌아가기
+
+# ==============================================================================
+# Search
+# ==============================================================================
+# Strings used in the search feature for finding entries and assets.
+
+# Search page: headings and aria-labels
+search_results: 검색 결과
+# {$terms} is the current search query text
+search_results_for_x: “{$terms}” 검색 결과
+
+# Search result announcements (ARIA live regions)
+# Entry search results with counts
+# {$terms} is the search query and {$count} is the number of matching entries
+viewing_entry_search_results: |
+  .input {$count :integer}
+  .match $count
+    0   {{ “{$terms}” 검색 결과를 표시하고 있습니다. 엔트리를 찾지 못했습니다. }}
+    *   {{ “{$terms}” 검색 결과를 표시하고 있습니다. 엔트리 {$count}개를 찾았습니다. }}
+# Asset search results with counts
+# {$terms} is the search query and {$count} is the number of matching assets
+viewing_asset_search_results: |
+  .input {$count :integer}
+  .match $count
+    0   {{ “{$terms}” 검색 결과를 표시하고 있습니다. 에셋을 찾지 못했습니다. }}
+    *   {{ “{$terms}” 검색 결과를 표시하고 있습니다. 에셋 {$count}개를 찾았습니다. }}
+
+# Result count labels
+# Used in search result headings to show counts
+# {$count} is the number of matching entries
+x_entries: |
+  .input {$count :integer}
+  .match $count
+    0   {{ 엔트리 없음 }}
+    *   {{ 엔트리 {$count}개 }}
+# {$count} is the number of matching assets
+x_assets: |
+  .input {$count :integer}
+  .match $count
+    0   {{ 에셋 없음 }}
+    *   {{ 에셋 {$count}개 }}
+
+# Empty state messages
+no_files_found: 파일을 찾을 수 없습니다.
+no_entries_found: 엔트리를 찾을 수 없습니다.
+
+# ==============================================================================
+# Asset Management
+# ==============================================================================
+# Strings for uploading, editing, and managing assets (images, documents, etc.).
+
+# Upload dialog: title and button label
+upload_assets: 새 에셋 업로드
+
+# Edit options menu: button and item labels
+edit_options: 편집 옵션
+show_edit_options: 편집 옵션 표시
+# Edit menu items with specific asset names
+edit_asset: 에셋 편집
+# {$name} is the selected asset name
+edit_x: '{$name} 편집'
+
+# Asset text editor: switch for line wrapping
+wrap_long_lines: 긴 줄 자동 줄바꿈
+
+# Rename asset: dialog and validation
+rename_asset: 에셋 이름 변경
+# {$name} is the current asset name
+rename_x: '{$name} 이름 변경'
+# Dialog body text indicating how many entries reference this asset
+# {$count} is the number of entries that currently reference the asset
+enter_new_name_for_asset: |
+  .input {$count :integer}
+  .match $count
+    0   {{ 아래에 새 이름을 입력하십시오. }}
+    *   {{ 아래에 새 이름을 입력하십시오. 이 에셋을 사용하는 엔트리 {$count}개도 함께 업데이트됩니다. }}
+# Validation errors for asset renaming
+enter_new_name_for_asset_error:
+  empty: 파일 이름은 비워 둘 수 없습니다.
+  character: 파일 이름에는 특수 문자를 사용할 수 없습니다.
+  duplicate: 이 파일 이름은 다른 에셋에서 사용 중입니다.
+
+# Replace asset: menu item and dialog title
+replace_asset: 에셋 교체
+# {$name} is the asset being replaced
+replace_x: '{$name} 교체'
+
+# File selection prompts: drop zones and file pickers
+# Browse prompt shown when drag-and-drop is unavailable on desktop and pointer devices
+click_to_browse: 클릭하여 찾아보기…
+# Browse prompt shown on touch devices
+tap_to_browse: 탭하여 찾아보기…
+# Drop zone text with browse button
+# {$count} is the number of files expected by the current picker mode
+drop_files_or_click_to_browse: |
+  여기에 파일을 놓거나 클릭하여 찾아보기…
+# Partial drop zone text (ends with inline button)
+# {$count} is the number of files expected by the current picker mode
+# After the “or” text, the inline buttons are rendered with the localized strings
+drop_files_or: |
+  여기에 파일을 놓거나
+# Image-specific drop zone text
+# {$count} is the number of image files expected by the current picker mode
+# After the “or” text, the inline buttons are rendered with the localized strings
+drop_image_files_or: |
+  여기에 이미지 파일을 놓거나
+
+# File picker and clipboard actions used by upload controls
+browse: 찾아보기
+# Generic clipboard paste action used by non-image file fields
+paste: 붙여넣기
+# Clipboard paste action used by image fields
+paste_image: 이미지 붙여넣기
+
+# Clipboard paste errors
+no_image_in_clipboard: 클립보드에 이미지가 없습니다.
+clipboard_access_denied: 클립보드 접근이 거부되었습니다.
+
+# Drag-and-drop overlay text (shown while dragging)
+# {$count} is the number of files expected by the current picker mode
+drop_files_here: |
+  여기에 파일을 놓으십시오
+
+# File type validation errors
+unsupported_file_type: 지원되지 않는 파일 형식
+# {$type} is the expected asset type label, such as image or document
+dropped_file_type_mismatch: '놓으신 파일이 다음 형식 중 하나가 아닙니다: {$types}. 다시 시도하십시오.'
+dropped_image_type_mismatch: '놓으신 파일은 지원되지 않습니다. 다음 형식의 이미지만 사용할 수 있습니다: {$types}. 다시 시도하십시오.'
+
+# File chooser button label
+# {$count} is the number of files the picker allows the user to choose
+choose_files: |
+  파일 선택
+
+# ==============================================================================
+# Delete Confirmations
+# ==============================================================================
+# Confirmation dialogs for deleting assets and entries.
+
+# Delete assets: dialog titles and confirmation messages
+# {$count} is the number of assets targeted by the action
+delete_assets: |
+  에셋 삭제
+# {$count} is the number of selected assets
+delete_selected_assets: |
+  선택한 에셋 삭제
+confirm_deleting_this_asset: 이 에셋을 삭제하시겠습니까?
+# {$count} is the number of selected assets
+confirm_deleting_selected_assets: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 선택한 에셋 {$count}개를 삭제하시겠습니까? }}
+confirm_deleting_all_assets: 모든 에셋을 삭제하시겠습니까?
+
+# Delete entries: dialog titles and confirmation messages
+# {$count} is the number of entries targeted by the action
+delete_entries: |
+  엔트리 삭제
+# {$count} is the number of selected entries
+delete_selected_entries: |
+  선택한 엔트리 삭제
+confirm_deleting_this_entry: 이 엔트리를 삭제하시겠습니까?
+confirm_deleting_this_entry_with_assets: 이 엔트리와 관련 에셋을 삭제하시겠습니까?
+# {$count} is the number of selected entries
+confirm_deleting_selected_entries: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 선택한 엔트리 {$count}개를 삭제하시겠습니까? }}
+# {$count} is the number of selected entries whose associated assets would also be removed
+confirm_deleting_selected_entries_with_assets: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 선택한 엔트리 {$count}개와 관련 에셋을 삭제하시겠습니까? }}
+confirm_deleting_all_entries: 모든 엔트리를 삭제하시겠습니까?
+confirm_deleting_all_entries_with_assets: 모든 엔트리와 관련 에셋을 삭제하시겠습니까?
+
+# ==============================================================================
+# Entry Reordering
+# ==============================================================================
+# Strings for manually reordering entries via drag-and-drop.
+
+# Reorder mode: toggle buttons
+reorder_entries: 엔트리 순서 변경
+done_reordering_entries: 엔트리 순서 변경 완료
+cancel_reordering_entries: 엔트리 순서 변경 취소
+
+# Reorder error message
+saving_reorder_failed: 새 엔트리 순서를 저장하지 못했습니다. 다시 시도하십시오.
+
+# ==============================================================================
+# File Upload and Processing
+# ==============================================================================
+# Strings for file upload dialogs, progress indicators, and validation.
+
+# Processing indicator shown during file preparation
+# {$count} is the number of files currently being processed
+processing_files: |
+  파일을 처리하고 있습니다. 시간이 다소 걸릴 수 있습니다.
+
+# Uploading section aria-label
+uploading_files: 파일 업로드 중
+
+# Replace file confirmation
+# Dialog body when replacing an existing file
+# {$name} is the existing file name that will be replaced
+confirm_replacing_file: '“{$name}”이(가) 다음 파일로 교체됩니다:'
+
+# Upload confirmation with destination folder
+# {$folder} is the destination folder label and {$count} is the number of files being uploaded
+confirm_uploading_files: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 다음 파일 {$count}개가 “{$folder}” 폴더에 저장됩니다: }}
+# File size validation
+# Warning section for files exceeding size limits
+oversized_files: 용량 초과 파일
+# {$size} is the maximum allowed file size and {$count} is the number of oversized files
+warning_oversized_files: |
+  해당 파일은 최대 용량 {$size}을(를) 초과하여 업로드할 수 없습니다. 용량을 줄이거나 다른 파일을 선택하십시오.
+
+# File integrity validation
+# Warning section for files that cannot be decoded
+invalid_files: 잘못된 파일
+# {$count} is the number of invalid files
+warning_invalid_files: |
+  해당 파일은 손상되었거나 내용이 파일 확장자와 일치하지 않아 업로드할 수 없습니다. HEIC 이미지를 JPEG 파일로 저장한 경우처럼 사진을 변환하지 않고 이름만 바꿨을 때 자주 발생합니다. 파일을 변환한 후 다시 시도하십시오.
+
+# File name conflict resolution
+# {$count} is the number of conflicting file names in the target folder
+file_name_conflict_confirmation: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 이 폴더에 이름이 같은 파일 {$count}개가 이미 있습니다. 교체하시겠습니까? }}
+# {$name} is the conflicting file name when there is exactly one conflict; {$count} is the total conflict count
+file_name_conflict_confirmation_with_name: |
+  .input {$count :integer}
+  .input {$name :string}
+  .match $count
+    1   {{ 이 폴더에 “{$name}” 파일이 이미 있습니다. 교체하시겠습니까? }}
+    *   {{ 이 폴더에 이름이 같은 파일 {$count}개가 이미 있습니다. 교체하시겠습니까? }}
+file_name_conflict_resolution: 파일 이름 충돌 해결
+# Option to keep both files (rename the new one)
+keep_both: 둘 다 유지
+
+# Upload progress and error messages
+uploading_files_progress: 업로드하는 중…
+uploading_files_failed: 업로드에 실패했습니다.
+
+# File metadata display
+# Shows file type and size in upload preview and asset info
+# {$type} is the localized file type label and {$size} is the formatted file size
+file_meta: '{$type} · {$size}'
+# Appended when a file was auto-converted (e.g., HEIF to JPEG)
+# {$type} is the original file type before conversion
+file_meta_converted_from_x: ({$type}에서 변환됨)
+
+# ==============================================================================
+# Entry Management
+# ==============================================================================
+# Strings for creating and managing entries in collections
+
+# Empty state messages
+no_entries_created: 이 컬렉션에는 아직 엔트리가 없습니다.
+# Button to create first entry
+create_new_entry: 새 엔트리 만들기
+# “Entry” option label in the create button menu
+entry: 엔트리
+
+# Special entry types
+# Fallback label for collection index files when no custom label is configured
+index_file: 인덱스 파일
+
+# Empty state for file collections
+no_files_in_collection: 이 컬렉션에는 사용할 수 있는 파일이 없습니다.
+
+# Entry duplication
+duplicate_entry: 엔트리 복제
+entry_duplicated: 엔트리가 새 초안으로 복제되었습니다.
+
+# Validation errors
+# Toast shown when entry has validation errors preventing save
+# {$count} is the number of fields with validation errors
+entry_validation_errors: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 필드 {$count}개에 오류가 있습니다. 엔트리를 저장하시려면 오류를 수정하십시오. }}
+
+# ==============================================================================
+# Success Notifications
+# ==============================================================================
+# Toast notifications shown after successful operations.
+
+# Entry operations
+# {$count} is the number of entries affected by the operation
+entry_saved: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 엔트리 {$count}개가 저장되었습니다. }}
+entry_saved_and_published: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 엔트리 {$count}개가 저장 및 게시되었습니다. }}
+entries_deleted: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 엔트리 {$count}개가 삭제되었습니다. }}
+
+# Asset operations
+# {$count} is the number of assets or asset-derived values affected by the operation
+assets_saved: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 에셋 {$count}개가 저장되었습니다. }}
+assets_saved_and_published: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 에셋 {$count}개가 저장 및 게시되었습니다. }}
+asset_urls_copied: |
+  .input {$count :integer}
+  .match $count
+    *   {{ URL {$count}개를 클립보드에 복사했습니다. }}
+asset_paths_copied: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 파일 경로 {$count}개를 클립보드에 복사했습니다. }}
+asset_data_copied: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 파일 {$count}개의 데이터를 클립보드에 복사했습니다. }}
+assets_downloaded: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 에셋 {$count}개를 다운로드했습니다. }}
+assets_moved: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 에셋 {$count}개를 이동했습니다. }}
+assets_renamed: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 에셋 {$count}개의 이름을 변경했습니다. }}
+assets_deleted: |
+  .input {$count :integer}
+  .match $count
+    *   {{ 에셋 {$count}개를 삭제했습니다. }}
+
+# ==============================================================================
+# Content Editor
+# ==============================================================================
+# Strings for the main content/entry editor interface.
+
+# Editor container aria-label
+content_editor: 콘텐츠 에디터
+
+# Draft backup: restore dialog
+restore_backup_title: 초안 복원
+# {$datetime} is the localized timestamp of the saved draft backup
+restore_backup_description: 이 엔트리에는 {$datetime}에 저장된 백업이 있습니다. 편집 중이던 초안을 복원하시겠습니까?
+
+# Draft backup notifications
+draft_backup_saved: 초안 백업이 저장되었습니다.
+draft_backup_restored: 초안 백업이 복원되었습니다.
+draft_backup_deleted: 초안 백업이 삭제되었습니다.
+
+# Editor toolbar actions
+cancel_editing: 편집 취소
+
+# Editor page titles and announcements
+# Creating a new entry
+# {$name} is the singular label of the collection being created in
+create_entry_title: '{$name} 만들기'
+# {$collection} is the collection label
+create_entry_announcement: “{$collection}” 컬렉션에 새 엔트리를 만들고 있습니다.
+# Editing an existing entry
+# {$collection} is the collection label and {$entry} is the entry label or slug
+edit_entry_title: '{$collection} › {$entry}'
+# {$entry} is the current entry label and {$collection} is the collection label
+edit_entry_announcement: “{$collection}” 컬렉션의 “{$entry}” 엔트리를 편집하고 있습니다.
+# {$file} is the file name and {$collection} is the collection label
+edit_file_announcement: “{$collection}” 컬렉션의 “{$file}” 파일을 편집하고 있습니다.
+# {$file} is the singleton file name
+edit_singleton_announcement: “{$file}” 파일을 편집하고 있습니다.
+
+# Save button variants
+# Shown when CI skip is enabled/disabled
+save_and_publish: 저장 및 게시
+save_without_publishing: 게시하지 않고 저장
+
+# Editor options menu
+show_editor_options: 에디터 옵션 표시
+editor_options: 에디터 옵션
+
+# Preview controls
+show_preview: 미리 보기 표시
+
+# Editor settings
+sync_scrolling: 스크롤 동기화
+
+# Locale controls
+switch_locale: 로케일 전환
+# Short status indicators appended to locale names
+locale_content_disabled_short: (비활성화됨)
+locale_content_error_short: (오류)
+
+# Pane labels
+edit: 편집
+preview: 미리 보기
+
+# Pane controls; not to be confused with pages
+swap_panes: 창 위치 바꾸기
+
+# Locale-specific pane labels
+# {$locale} is the localized language name for the current content pane, e.g., English
+edit_x_locale: '{$locale} 콘텐츠 편집'
+preview_x_locale: '{$locale} 콘텐츠 미리 보기'
+
+# Preview iframe labels
+content_preview: 콘텐츠 미리 보기
+
+# Locale content options
+# {$locale} is the localized language name for the content options menu, e.g., English
+show_content_options_x_locale: '{$locale} 콘텐츠 옵션 표시'
+content_options_x_locale: '{$locale} 콘텐츠 옵션'
+
+# Field container labels
+# {$field} is the field’s display label
+x_field: “{$field}” 필드
+
+# Field options menu
+show_field_options: 필드 옵션 표시
+field_options: 필드 옵션
+
+# Unsupported field type error
+# {$name} is the unsupported field widget or type name
+unsupported_field_type_x: '지원되지 않는 필드 유형: {$name}'
+
+# Locale management actions
+# {$locale} is the localized language name being enabled or disabled, e.g., English
+enable_x_locale: '{$locale} 활성화'
+reenable_x_locale: '{$locale} 다시 활성화'
+disable_x_locale: '{$locale} 비활성화'
+
+# Locale status messages
+# {$locale} is the localized language name affected by the status change, e.g., English
+locale_x_has_been_disabled: '{$locale} 콘텐츠가 비활성화되었습니다.'
+locale_x_now_disabled: '{$locale} 콘텐츠가 비활성화되었습니다. 엔트리를 저장하면 삭제됩니다.'
+
+# Repository and site links
+view_in_repository: 저장소에서 보기
+# {$service} is the external service label, such as GitHub or GitLab
+view_on_x: '{$service}에서 보기'
+view_on_live_site: 라이브 사이트에서 보기
+
+# Content copying from other locales
+copy_from: 다른 로케일에서 복사…
+# {$locale} is the localized language name of the source content being copied, e.g., English
+copy_from_x: '{$locale}에서 복사'
+
+# Translation features
+translation_options: 번역 옵션
+translate: 번역
+# {$count} is the number of fields selected for translation
+translate_fields: |
+  필드 번역
+translate_from: 다른 로케일에서 번역…
+# {$locale} is the localized language name of the source content being translated, e.g., English
+translate_from_x: '{$locale}에서 번역'
+
+# Revert changes
+revert_changes: 변경 사항 되돌리기
+revert_all_changes: 모든 변경 사항 되돌리기
+
+# Slug editing
+edit_slug: 슬러그 편집
+edit_slug_warning: 슬러그를 변경하면 이 엔트리를 가리키는 내부 및 외부 링크가 깨질 수 있습니다. 현재 Sveltia CMS는 Relation 필드로 만들어진 참조를 업데이트하지 않으므로, 다른 링크와 함께 그러한 참조도 직접 업데이트하셔야 합니다.
+edit_slug_error:
+  empty: 슬러그는 비워 둘 수 없습니다.
+  invalid: 슬러그에는 슬래시와 공백을 포함한 특수 문자를 사용할 수 없습니다.
+  duplicate: 이 슬러그는 다른 엔트리에서 사용 중입니다.
+
+# Required field indicator
+required: 필수
+
+# Editor operation feedback
+# Translation and copy operation status messages
+editor:
+  translation:
+    none: 번역할 내용이 없습니다.
+    started: 번역하는 중…
+    error: 번역에 실패했습니다.
+    # {$source} is the source language name and {$count} is the number of translated fields
+    complete: |
+      .input {$count :integer}
+      .match $count
+        0   {{ {$source}에서 번역된 필드가 없습니다. }}
+        *   {{ {$source}에서 필드 {$count}개를 번역했습니다. }}
+  copy:
+    none: 복사할 내용이 없습니다.
+    # {$source} is the source language name and {$count} is the number of copied fields
+    complete: |
+      .input {$count :integer}
+      .match $count
+        0   {{ {$source}에서 복사된 필드가 없습니다. }}
+        *   {{ {$source}에서 필드 {$count}개를 복사했습니다. }}
+
+# ==============================================================================
+# Field Validation
+# ==============================================================================
+# Inline validation error messages for form fields.
+
+validation:
+  # Required field missing
+  value_missing: 필수 입력 항목입니다.
+
+  # Minimum value/count not met
+  range_underflow:
+    # {$min} is the minimum allowed value, already formatted for the input type
+    datetime-local: 날짜/시간은 {$min} 이후여야 합니다.
+    date: 날짜는 {$min} 이후여야 합니다.
+    time: 시간은 {$min} 이후여야 합니다.
+    number: 값은 {$min} 이상이어야 합니다.
+    # {$min} is the minimum number of selected options
+    select: |
+      .input {$min :integer}
+      .match $min
+        *   {{ 최소 {$min}개 이상 선택하셔야 합니다. }}
+    # {$min} is the minimum number of list items
+    add: |
+      .input {$min :integer}
+      .match $min
+        *   {{ 최소 {$min}개 이상 추가하셔야 합니다. }}
+
+  # Maximum value/count exceeded
+  range_overflow:
+    # {$max} is the maximum allowed value, already formatted for the input type
+    datetime-local: 날짜/시간은 {$max} 이전이어야 합니다.
+    date: 날짜는 {$max} 이전이어야 합니다.
+    time: 시간은 {$max} 이전이어야 합니다.
+    number: 값은 {$max} 이하여야 합니다.
+    # {$max} is the maximum number of selected options
+    select: |
+      .input {$max :integer}
+      .match $max
+        *   {{ {$max}개를 초과하여 선택하실 수 없습니다. }}
+    # {$max} is the maximum number of list items
+    add: |
+      .input {$max :integer}
+      .match $max
+        *   {{ {$max}개를 초과하여 추가하실 수 없습니다. }}
+
+  # String length constraints
+  # {$min :integer} and {$max :integer} are character-count limits
+  too_short: |
+    .input {$min :integer}
+    .match $min
+      *   {{ 최소 {$min}자 이상 입력하셔야 합니다. }}
+  too_long: |
+    .input {$max :integer}
+    .match $max
+      *   {{ {$max}자를 초과하여 입력하실 수 없습니다. }}
+
+  # Type validation errors
+  type_mismatch:
+    number: 숫자를 입력하십시오.
+    email: 올바른 이메일 주소를 입력하십시오.
+    url: 올바른 URL을 입력하십시오.
+
+  # Custom field validation error
+  invalid_value: 값이 올바르지 않습니다.
+  unexpected_error: 예기치 않은 오류가 발생했습니다.
+
+# ==============================================================================
+# Entry Sidebar
+# ==============================================================================
+# Panels shown in the entry editor sidebar.
+
+entry_sidebar:
+  # Sidebar tab list aria-label
+  sidebar_panels: 사이드바 패널
+
+  # Validation panel: shows field validation errors
+  validation:
+    title: 검증
+    placeholder: 검증 결과가 여기에 표시됩니다.
+    no_errors_found: 오류가 없습니다.
+
+  # History panel: shows entry commit history
+  history:
+    title: 기록
+    fetch_failed: 기록을 불러오지 못했습니다.
+    no_history: 기록이 없습니다.
+
+  # Backlinks panel: shows entries referencing this entry
+  backlinks:
+    title: 백링크
+    no_entries: 이 엔트리를 참조하는 엔트리가 없습니다.
+
+# Entry save error dialog
+saving_entry:
+  error:
+    title: 오류
+    description: 엔트리를 저장하는 중 오류가 발생했습니다. 나중에 다시 시도하십시오.
+
+# ==============================================================================
+# Asset Editor
+# ==============================================================================
+# Strings for the asset details and editing interface.
+
+# Asset details announcement
+# {$name} is the selected asset name
+viewing_x_asset_details: “{$name}” 에셋의 세부 정보를 표시하고 있습니다.
+
+# Asset editor container aria-label
+asset_editor: 에셋 에디터
+
+# Preview unavailable message
+preview_unavailable: 미리 보기를 사용할 수 없습니다.
+
+# Copy menu items: public URLs, file paths, file data
+# {$count} is the number of selected assets
+public_urls: |
+  공개 URL
+# {$count} is the number of selected assets
+file_paths: |
+  파일 경로
+file_data: 파일 데이터
+
+# ==============================================================================
+# Asset Info Panel
+# ==============================================================================
+# Section headings and labels in the asset information panel.
+
+# Panel title and empty state shown in the asset sidebar
+asset_info: 에셋 정보
+select_asset_show_info: 정보를 보시려면 에셋을 선택하십시오.
+
+kind: 종류
+size: 용량
+dimensions: 크기
+duration: 재생 시간
+# Short heading for a list of entries using the selected asset
+used_in: 사용된 위치
+created_date: 만든 날짜
+location: 위치
+
+# Map aria-label showing GPS coordinates
+# {$latitude} and {$longitude} are the formatted coordinate values displayed on the map
+map_lat_lng: 위도 {$latitude}, 경도 {$longitude}을(를) 표시하는 지도
+
+# ==============================================================================
+# List and Object Field Controls
+# ==============================================================================
+# Controls for List and Object field types.
+
+# List item actions
+remove_this_item: 이 항목 제거
+move_up: 위로 이동
+move_down: 아래로 이동
+
+# Add item button label
+# Example: “Add Image”, “Add Author”
+# {$name} is the label of the item type that can be added
+add_x: '{$name} 추가'
+
+# List item context menu
+add_item_above: 위에 항목 추가
+add_item_below: 아래에 항목 추가
+
+# Variable-type list selector
+select_list_type: 목록 유형 선택
+
+# Variable-type mismatch
+unknown_variable_type: 알 수 없는 유형이어서 이 항목을 표시할 수 없습니다. 자세한 내용은 브라우저 콘솔을 확인하십시오.
+
+# ==============================================================================
+# Field Widgets
+# ==============================================================================
+# Strings for specific field widget types.
+
+# Color field: opacity slider
+opacity: 불투명도
+
+# Select field: empty option placeholder
+unselected_option: (없음)
+
+# Select Assets dialog
+assets_dialog:
+  # Dialog titles for different selection modes
+  title:
+    file: 파일 선택
+    image: 이미지 선택
+
+  # Search input labels
+  search_for_file: 파일 검색
+  search_for_image: 이미지 검색
+
+  # Locations panel aria-label
+  locations: 위치
+
+  # Asset folder options
+  folder:
+    field: 필드 에셋
+    entry: 엔트리 에셋
+    file: 파일 에셋
+    collection: 컬렉션 에셋
+    global: 전역 에셋
+
+  # Error messages
+  error:
+    invalid_key: API 키가 유효하지 않거나 만료되었습니다. 다시 확인한 후 시도하십시오.
+    search_fetch_failed: 에셋을 검색하는 중 오류가 발생했습니다. 나중에 다시 시도하십시오.
+    image_fetch_failed: 선택하신 에셋을 다운로드하는 중 오류가 발생했습니다. 나중에 다시 시도하십시오.
+
+  # Stock photo panels
+  available_images: 사용 가능한 이미지
+
+  # URL entry option
+  enter_url: URL 입력
+  enter_file_url: '파일의 URL을 입력하십시오:'
+  enter_image_url: '이미지의 URL을 입력하십시오:'
+
+  # Large file warning dialog
+  large_file:
+    title: 큰 파일
+
+  # Invalid file warning dialog
+  invalid_file:
+    title: 잘못된 파일
+
+  # Warning dialog shown when files are rejected for more than one reason
+  rejected_files:
+    title: 파일을 업로드할 수 없음
+
+  # Photo credit dialog (stock photos)
+  photo_credit:
+    title: 사진 출처
+    description: '가능하면 다음 출처 표기를 사용하십시오:'
+
+  # Unsaved asset badge
+  unsaved: 저장되지 않음
+
+# Character counter: shows character count for text fields
+character_counter:
+  # {$count} is the current character count; {$min} and {$max} are configured limits
+  min_max: |
+    .input {$count :integer}
+    .match $count
+      0   {{ 입력된 문자가 없습니다. 최소: {$min}. 최대: {$max}. }}
+      *   {{ {$count}자 입력됨. 최소: {$min}. 최대: {$max}. }}
+  # {$count} is the current character count and {$min} is the minimum allowed count
+  min: |
+    .input {$count :integer}
+    .match $count
+      0   {{ 입력된 문자가 없습니다. 최소: {$min}. }}
+      *   {{ {$count}자 입력됨. 최소: {$min}. }}
+  # {$count} is the current character count and {$max} is the maximum allowed count
+  max: |
+    .input {$count :integer}
+    .match $count
+      0   {{ 입력된 문자가 없습니다. 최대: {$max}. }}
+      *   {{ {$count}자 입력됨. 최대: {$max}. }}
+
+# YouTube video player iframe title
+youtube_video_player: YouTube 동영상 플레이어
+
+# Date/time field: quick action buttons
+today: 오늘
+now: 지금
+
+# Rich-text editor: component field labels
+editor_components:
+  image: 이미지
+  src: 소스
+  alt: 대체 텍스트
+  title: 제목
+  link: 링크
+
+# Key-Value field: column headers and validation
+key_value:
+  key: 키
+  value: 값
+  action: 작업
+  empty_key: 키는 필수입니다.
+  duplicate_key: 키는 고유해야 합니다.
+
+# Map field: location search and geolocation
+find_place: 장소 찾기
+use_your_location: 현재 위치 사용
+
+# Geolocation error dialog
+geolocation_error_title: 위치 정보 오류
+geolocation_error_body: 위치를 가져오는 중 오류가 발생했습니다.
+geolocation_unsupported: 이 브라우저는 Geolocation API를 지원하지 않습니다.
+
+# Boolean field: display labels
+# Note that the keys must be quoted strings to avoid being interpreted as YAML booleans
+boolean:
+  'true': 예
+  'false': 아니요
+
+# ==============================================================================
+# Cloud Storage Services
+# ==============================================================================
+# Strings for external cloud storage service integrations.
+
+cloud_storage:
+  # Configuration error
+  invalid: 서비스가 올바르게 설정되지 않았습니다.
+
+  # Authentication states
+  auth:
+    api_key:
+      key_label: API 키
+      # {$key} is the credential label, e.g., API Key, and {$service} is the cloud service name
+      initial: '{$service}의 {$key}을(를) 입력하십시오.'
+      requested: 확인하는 중…
+      # {$key} is the credential label the user entered, e.g., API Key
+      error: 입력하신 {$key}이(가) 유효하지 않습니다. 다시 확인한 후 시도하십시오.
+    password:
+      # {$service} is the cloud service name
+      initial: '{$service}의 비밀번호를 입력하십시오.'
+      requested: 로그인하는 중…
+      error: 사용자 이름 또는 비밀번호가 올바르지 않습니다. 다시 확인한 후 시도하십시오.
+
+  # Service-specific configurations
+  cloudinary:
+    iframe_title: Cloudinary 미디어 라이브러리
+    activate:
+      button_label: Cloudinary 활성화
+      description: 로그인하신 후 로그인 버튼을 다시 클릭하여 계속 진행하십시오.
+    auth_key_label: API 시크릿
+    open_library: Cloudinary 열기
+
+  uploadcare:
+    auth_key_label: API 시크릿 키
+
+  aws_s3:
+    auth_key_label: 시크릿 액세스 키
+
+  cloudflare_r2:
+    auth_key_label: 시크릿 액세스 키
+
+  digitalocean_spaces:
+    auth_key_label: 시크릿 액세스 키
+
+# ==============================================================================
+# Configuration Validation
+# ==============================================================================
+# Error and warning messages for CMS configuration validation.
+
+config:
+  # Error count notice on entrance page
+  # {$count} is the number of configuration errors found
+  errors: |
+    CMS 설정에 오류가 있습니다. 문제를 해결한 후 다시 시도하십시오.
+
+  # Error location prefixes
+  error_locator:
+    # {$collection}, {$file}, {$component}, and {$field} are the offending config item names
+    collection: '{$collection} 컬렉션'
+    file: '{$file} 파일'
+    component: '{$component} 컴포넌트'
+    # Don’t localize `{$field}`
+    field: '`{$field}` 필드'
+
+  # Configuration error messages
+  error:
+    no_secure_context: Sveltia CMS는 HTTPS 또는 localhost URL에서만 작동합니다.
+    # {$count} is the number of insecure configuration file URLs
+    insecure_urls: |
+      설정 파일 URL은 HTTPS 프로토콜 또는 localhost 주소를 사용해야 합니다.
+    fetch_failed: 설정 파일을 가져오지 못했습니다.
+    # {$status} is the HTTP status code returned while fetching the config file
+    fetch_failed_not_ok: HTTP 응답이 상태 코드 {$status}(으)로 반환되었습니다.
+    # Don’t localize `config.yml`, `load_config_file: false`, and `CMS.init()`
+    fetch_failed_with_manual_init: '설정 파일을 가져오지 못했습니다. `config.yml` 파일이 로드되지 않도록 하려면 `CMS.init()`에 전달하는 설정 객체에 <a>`load_config_file: false`</a>를 추가하십시오.'
+    parse_failed: 설정 파일을 구문 분석하지 못했습니다.
+    parse_failed_invalid_object: 설정 파일이 유효한 JavaScript 객체가 아닙니다.
+    parse_failed_unsupported_type: 설정 파일이 유효한 파일 형식이 아닙니다. YAML, TOML, JSON만 지원됩니다.
+    no_collection: 컬렉션이 정의되지 않았습니다.
+    missing_backend: 백엔드가 정의되지 않았습니다.
+    missing_backend_name: 백엔드 이름이 정의되지 않았습니다.
+    # {$name} is the backend name from the CMS configuration
+    unsupported_known_backend: '{$name} 백엔드는 Sveltia CMS에서 <a>지원되지 않습니다</a>.'
+    # {$name} is the backend name from the CMS configuration
+    unsupported_deprecated_backend: 더 이상 사용되지 않는 {$name} 백엔드는 Sveltia CMS에서 <a>지원되지 않습니다</a>.
+    unsupported_custom_backend: 사용자 지정 백엔드는 Sveltia CMS에서 <a>지원되지 않습니다</a>.
+    unsupported_backend_suggestion: 대신 <a>지원되는 백엔드</a> 중 하나를 사용하십시오.
+    missing_repository: 저장소가 정의되지 않았습니다.
+    invalid_repository: 설정된 저장소가 올바르지 않습니다. “owner/repo” 형식이어야 합니다.
+    oauth_implicit_flow: 설정된 인증 방식(implicit flow)은 Sveltia CMS에서 지원되지 않습니다. 다른 <a>인증 방식</a>을 사용하십시오.
+    github_pkce_unsupported: GitHub의 제약으로 인해 PKCE 인증은 아직 지원되지 않습니다. 다른 <a>인증 방식</a>을 사용하십시오.
+    oauth_no_app_id: OAuth 애플리케이션 ID가 정의되지 않았습니다.
+    # Don’t localize `auth_methods`
+    no_auth_methods: '`auth_methods` 옵션에는 최소 한 가지 방식이 포함되어야 합니다.'
+    missing_media_folder: 미디어 폴더가 정의되지 않았습니다.
+    invalid_media_folder: 설정된 미디어 폴더가 올바르지 않습니다. 문자열이어야 합니다.
+    invalid_public_folder: 설정된 공개 폴더가 올바르지 않습니다. 문자열이어야 합니다.
+    public_folder_relative_path: 설정된 공개 폴더가 올바르지 않습니다. “/”로 시작하는 절대 경로여야 합니다.
+    public_folder_absolute_url: 공개 폴더 옵션에 절대 URL을 사용하는 것은 Sveltia CMS에서 지원되지 않습니다.
+    # Don’t localize `asset_collections`
+    invalid_asset_collections: '`asset_collections` 옵션이 올바르지 않습니다. 배열이어야 합니다.'
+    # {$count} is the 1-based asset collection index in the configuration array. Don’t localize `name`
+    missing_asset_collection_name: 에셋 컬렉션 {$count}에는 `name` 옵션이 비어 있지 않은 문자열로 정의되어야 합니다.
+    # {$name} is the invalid or duplicate asset collection name
+    invalid_asset_collection_name: 에셋 컬렉션 이름 `{$name}`이(가) 올바르지 않습니다. 특수 문자를 포함할 수 없습니다.
+    # {$name} is the duplicate asset collection name
+    duplicate_asset_collection_name: 에셋 컬렉션 이름은 고유해야 하지만 `{$name}`이(가) 두 번 이상 사용되었습니다.
+    # Don’t localize `media_folder`
+    asset_collection_invalid_media_folder: '`{$name}` 에셋 컬렉션에는 `media_folder` 옵션이 문자열로 정의되어야 합니다.'
+    # Don’t localize `folder`, `files`, and `divider`
+    invalid_collection_no_options: 컬렉션에는 `folder`, `files` 또는 `divider` 옵션 중 하나가 정의되어야 합니다.
+    # Don’t localize `folder`, `files`, and `divider`
+    invalid_collection_multiple_options: 컬렉션에는 `folder`, `files`, `divider` 옵션을 함께 사용할 수 없습니다.
+    # {$extension} is the file extension and {$format} is the configured content format
+    file_format_mismatch: '`{$extension}` 확장자가 `{$format}` 형식과 일치하지 않습니다.'
+    # {$slug} is the invalid slug template from the configuration; Don’t localize `path` and `slug`
+    invalid_slug_slash: 슬러그 템플릿 `{$slug}`은(는) 슬래시를 포함할 수 없으므로 올바르지 않습니다. 엔트리를 하위 폴더로 정리하시려면 `slug` 대신 `path` 옵션을 사용하십시오.
+    # {$count} is the 1-based collection index in the configuration array; Don’t localize `name`
+    missing_collection_name: 컬렉션 {$count}에는 `name` 옵션이 비어 있지 않은 문자열로 정의되어야 합니다.
+    # {$name} is the invalid or duplicate collection name
+    invalid_collection_name: 컬렉션 이름 `{$name}`이(가) 올바르지 않습니다. 특수 문자를 포함할 수 없습니다.
+    duplicate_collection_name: 컬렉션 이름은 고유해야 하지만 `{$name}`이(가) 두 번 이상 사용되었습니다.
+    # {$count} is the 1-based file index inside a file collection; Don’t localize `name`
+    missing_collection_file_name: 컬렉션 파일 {$count}에는 `name` 옵션이 비어 있지 않은 문자열로 정의되어야 합니다.
+    # {$name} is the invalid or duplicate collection file name
+    invalid_collection_file_name: 컬렉션 파일 이름 `{$name}`이(가) 올바르지 않습니다. 특수 문자를 포함할 수 없습니다.
+    duplicate_collection_file_name: 컬렉션 파일 이름은 고유해야 하지만 `{$name}`이(가) 두 번 이상 사용되었습니다.
+    # Don’t localize `fields`
+    collection_no_fields: 컬렉션에는 `fields` 옵션이 최소 한 개의 필드와 함께 정의되어야 합니다.
+    # Don’t localize `fields`
+    collection_file_no_fields: 컬렉션 파일에는 `fields` 옵션이 최소 한 개의 필드와 함께 정의되어야 합니다.
+    # Don’t localize `i18n`, `locale` and `file`
+    collection_file_i18n_required: '`file` 경로에 `locale` 자리 표시자를 사용하는 경우 컬렉션 파일에는 `i18n` 옵션이 정의되어야 합니다.'
+    # {$count} is the 1-based field index in the current fields array; Don’t localize `name`
+    missing_field_name: 필드 {$count}에는 `name` 옵션이 비어 있지 않은 문자열로 정의되어야 합니다.
+    # {$name} is the invalid or duplicate field name
+    invalid_field_name: 필드 이름 `{$name}`이(가) 올바르지 않습니다. 특수 문자를 포함할 수 없습니다. 필드를 중첩하시려면 <a>점 표기법 대신 Object 필드를 사용</a>하십시오.
+    duplicate_field_name: 필드 이름은 고유해야 하지만 `{$name}`이(가) 두 번 이상 사용되었습니다.
+    # {$count} is the 1-based variable type index in the current types array
+    missing_variable_type: 변수 유형 {$count}에는 `name` 옵션이 비어 있지 않은 문자열로 정의되어야 합니다.
+    # {$name} is the invalid or duplicate variable type name
+    invalid_variable_type: 변수 유형 이름 `{$name}`이(가) 올바르지 않습니다. 특수 문자를 포함할 수 없습니다.
+    duplicate_variable_type: 변수 유형 이름은 고유해야 하지만 `{$name}`이(가) 두 번 이상 사용되었습니다.
+    date_field_type: '더 이상 사용되지 않는 Date 필드 유형은 Sveltia CMS에서 지원되지 않습니다. 대신 `type: date` 옵션과 함께 DateTime 필드 유형을 사용하십시오.'
+    # {$timeZone} is the invalid IANA timezone identifier from the configuration
+    invalid_timezone: '잘못된 시간대: {$timeZone}. `America/New_York` 또는 `Asia/Tokyo`와 같은 유효한 IANA 시간대 식별자여야 합니다.'
+    # {$prop} is the deprecated option name and {$newProp} is the supported replacement option
+    unsupported_deprecated_option: 더 이상 사용되지 않는 `{$prop}` 옵션은 Sveltia CMS에서 지원되지 않습니다. 대신 `{$newProp}` 옵션을 사용하십시오.
+    # Don’t localize `allow_multiple`, `multiple`, and `false`
+    allow_multiple: '`allow_multiple` 옵션은 Sveltia CMS에서 지원되지 않습니다. 대신 기본값이 `false`인 `multiple` 옵션을 사용하십시오.'
+    # Don’t localize `field`, `fields`, and `types`
+    invalid_list_field: List 필드에는 `field`, `fields`, `types` 옵션을 함께 사용할 수 없습니다.
+    # {$widget} is the configured widget value of the invalid variable type; Don’t localize `widget` and `object`
+    invalid_list_variable_type: List 필드의 변수 유형이 올바르지 않습니다. `widget` 옵션이 `{$widget}`(으)로 설정되어 있지만 `object`여야 합니다.
+    # Don’t localize `fields`, and `types`
+    invalid_object_field: Object 필드에는 `fields`와 `types` 옵션을 함께 사용할 수 없습니다.
+    # Don’t localize `fields`, and `types`
+    object_field_missing_fields: Object 필드에는 `fields` 또는 `types` 옵션 중 하나가 정의되어야 합니다.
+    # {$collection}, {$file}, and {$field} are referenced names that could not be resolved
+    relation_field_invalid_collection: 참조된 `{$collection}` 컬렉션이 올바르지 않거나 정의되지 않았습니다.
+    relation_field_invalid_collection_file: 참조된 `{$file}` 파일이 올바르지 않거나 정의되지 않았습니다.
+    # Don’t localize `file`
+    relation_field_missing_file_name: 파일 컬렉션에 대한 관계에는 `file` 옵션이 정의되어야 합니다.
+    relation_field_invalid_value_field: 참조된 값 필드 `{$field}`이(가) 올바르지 않거나 정의되지 않았습니다.
+    unexpected: 예기치 않은 오류
+
+  # Warning messages (logged to console)
+  warning:
+    oauth_no_app_id: OAuth 애플리케이션 ID가 정의되지 않았습니다. 사용자는 로그인하려면 액세스 토큰을 제공해야 합니다.
+    editorial_workflow_unsupported: 편집 워크플로는 Sveltia CMS에서 아직 지원되지 않습니다.
+    open_authoring_unsupported: 오픈 오소링은 Sveltia CMS에서 아직 지원되지 않습니다.
+    nested_collections_unsupported: 중첩 컬렉션은 Sveltia CMS에서 아직 지원되지 않습니다.
+    # {$prop} is the unsupported option name that will be ignored
+    unsupported_ignored_option: '`{$prop}` 옵션은 Sveltia CMS에서 지원되지 않습니다. 이 옵션은 무시됩니다.'
+    # Don’t localize `picker_utc`, `input_timezone`, and `output_utc`
+    conflicting_timezone_options: '`picker_utc`와 최신 시간대 옵션(`input_timezone` 또는 `output_utc`)이 모두 설정되어 있습니다. 최신 옵션이 우선 적용됩니다. 설정에서 `picker_utc`를 제거하시는 것을 고려해 보십시오.'
+
+  # Compatibility link appended to unsupported feature messages
+  compatibility_link: '자세한 내용은 호환성 참고 사항을 확인하십시오: {$link}'
+
+  # Console tip shown after config load
+  schema_tip: 더 나은 개발 경험을 위해 Sveltia CMS의 JSON 스키마로 설정 파일을 검증할 수 있습니다. 자세한 내용은 {$link}을(를) 참조하십시오.
+
+# ==============================================================================
+# Local Workflow
+# ==============================================================================
+# Strings for the Local Workflow feature (local repository support).
+
+local_workflow:
+  # Badge text in account button
+  indicator: 로컬
+  # Browser compatibility warnings
+  unsupported_browser: 사용 중이신 브라우저에서는 로컬 워크플로가 지원되지 않습니다. Chrome 또는 Edge를 사용하십시오.
+  disabled: 사용 중이신 브라우저에서 로컬 워크플로가 비활성화되어 있습니다. <a>활성화 방법을 확인하십시오</a>.
+
+# ==============================================================================
+# Editorial Workflow
+# ==============================================================================
+# Column headings for the Editorial Workflow feature (content review process).
+
+status:
+  drafts: 초안
+  in_review: 검토 중
+  ready: 준비됨
+
+# ==============================================================================
+# Settings Dialog
+# ==============================================================================
+# Strings for the settings/preferences dialog and its panels.
+
+# Settings page aria-label
+categories: 범주
+
+# Site Configuration Editor
+site_configuration_editor: 사이트 설정 에디터
+
+# Preferences panels
+prefs:
+  # API key management feedback messages
+  changes:
+    api_key_saved: API 키가 저장되었습니다.
+    api_key_removed: API 키가 제거되었습니다.
+    api_key_invalid: 입력하신 API 키가 유효하지 않습니다. 다시 확인한 후 시도하십시오.
+
+  # Preferences operation errors
+  error:
+    permission_denied: 쿠키 저장소 접근이 거부되었습니다. 브라우저 권한을 확인한 후 다시 시도하십시오.
+
+  # Appearance panel
+  appearance:
+    title: 모양
+    theme: 테마
+    select_theme: 테마 선택
+
+  # Theme options
+  theme:
+    auto: 자동
+    dark: 어둡게
+    light: 밝게
+
+  # Language panel
+  language:
+    title: 언어
+    ui_language:
+      title: 사용자 인터페이스 언어
+      select_language: 언어 선택
+
+  # Contents panel
+  contents:
+    title: 콘텐츠
+    editor:
+      title: 에디터
+      use_draft_backup:
+        switch_label: 엔트리 초안 자동 백업
+      close_on_save:
+        switch_label: 초안을 저장한 후 에디터 닫기
+      close_with_escape:
+        switch_label: Escape 키로 에디터 닫기
+
+  # Internationalization panel
+  i18n:
+    title: 국제화
+    translators:
+      default:
+        title: 기본 번역 서비스
+        select_service: 서비스 선택
+      api_keys:
+        title: 번역 서비스 API 키
+        description: <a>번역 서비스</a>의 API 키를 관리합니다.
+      # API key input label, e.g., “DeepL Key”
+      # {$service} is the translation service name
+      field_label: '{$service} 키'
+      # Description with embedded links
+      # {$service} is the service name; {$homeHref} and {$apiKeyHref} are HTML anchor attributes for the service homepage and API key page
+      description: <a {$homeHref}>{$service}</a>에 가입하신 후 여기에 <a {$apiKeyHref}>API 키</a>를 입력하시면 텍스트 입력 필드를 빠르게 번역할 수 있습니다.
+
+  # Media panel
+  media:
+    title: 미디어
+    stock_photos:
+      api_keys:
+        title: 스톡 사진 서비스 API 키
+        description: <a>스톡 사진 서비스</a>의 API 키를 관리합니다.
+      # API key input label, e.g., “Unsplash API Key”
+      # {$service} is the stock photo service name
+      field_label: '{$service} API 키'
+      # Description with embedded links
+      # {$service} is the service name; {$homeHref} and {$apiKeyHref} are HTML anchor attributes for the service homepage and API key page
+      description: <a {$homeHref}>{$service} API</a>에 가입하신 후 여기에 <a {$apiKeyHref}>API 키</a>를 입력하시면 이미지 입력 필드에 무료 스톡 사진을 삽입할 수 있습니다.
+      # Photo credit attribution
+      # {$service} is the stock photo service name
+      credit: '{$service}에서 제공하는 사진'
+      no_services: 설정된 <a>스톡 사진 서비스</a>가 없습니다.
+    cloud_storage:
+      api_keys:
+        title: 클라우드 스토리지 서비스 API 키
+        description: <a>클라우드 스토리지 서비스</a>의 API 키를 관리합니다.
+      # API key input label
+      # {$service} is the cloud storage service name
+      field_label: '{$service} API 키'
+      no_services: 설정된 <a>클라우드 스토리지 서비스</a>가 없습니다.
+
+  # Accessibility panel
+  accessibility:
+    title: 접근성
+    underline_links:
+      title: 링크 밑줄
+      description: 엔트리 미리 보기와 사용자 인터페이스 레이블의 링크에 밑줄을 표시합니다.
+      switch_label: 항상 링크에 밑줄 표시
+
+  # Advanced panel
+  advanced:
+    title: 고급
+    beta:
+      title: 베타 기능
+      description: 불안정하거나 현지화되지 않았을 수 있는 일부 베타 기능을 활성화합니다.
+      switch_label: 베타 프로그램 참여
+    developer_mode:
+      title: 개발자 모드
+      description: 자세한 콘솔 로그와 네이티브 컨텍스트 메뉴 등 개발자용 기능을 활성화합니다.
+      switch_label: 개발자 모드 활성화
+    deploy_hook:
+      title: 배포 훅
+      description: 변경 사항 게시를 선택하여 배포를 수동으로 실행할 때 호출할 웹훅 URL을 입력하십시오. GitHub Actions를 사용하시는 경우 비워 두셔도 됩니다.
+      # Hook URL input
+      url:
+        field_label: 훅 URL
+        saved: 훅 URL이 저장되었습니다.
+        removed: 훅 URL이 제거되었습니다.
+      # Authorization header input
+      auth:
+        field_label: 'Authorization 헤더(예: Bearer <token>)(선택 사항)'
+        saved: Authorization 헤더가 저장되었습니다.
+        removed: Authorization 헤더가 제거되었습니다.
+
+# ==============================================================================
+# Keyboard Shortcuts
+# ==============================================================================
+# Action descriptions for the keyboard shortcuts dialog.
+
+keyboard_shortcuts_:
+  view_content_library: 콘텐츠 라이브러리 보기
+  view_asset_library: 에셋 라이브러리 보기
+  search: 엔트리 및 에셋 검색
+  create_entry: 새 엔트리 만들기
+  save_entry: 엔트리 저장
+  cancel_editing: 엔트리 편집 취소
+
+# ==============================================================================
+# File Type Labels
+# ==============================================================================
+# Display labels for file types shown in asset info and upload previews.
+
+file_type_labels:
+  # Image formats
+  avif: AVIF 이미지
+  bmp: 비트맵 이미지
+  gif: GIF 이미지
+  ico: 아이콘
+  jpeg: JPEG 이미지
+  jpg: JPEG 이미지
+  png: PNG 이미지
+  svg: SVG 이미지
+  tif: TIFF 이미지
+  tiff: TIFF 이미지
+  webp: WebP 이미지
+  # Video formats
+  avi: AVI 동영상
+  m4v: MP4 동영상
+  mov: QuickTime 동영상
+  mp4: MP4 동영상
+  mpeg: MPEG 동영상
+  mpg: MPEG 동영상
+  ogg: Ogg 동영상
+  ogv: Ogg 동영상
+  ts: MPEG 동영상
+  webm: WebM 동영상
+  3gp: 3GPP 동영상
+  3g2: 3GPP2 동영상
+  # Audio formats
+  aac: AAC 오디오
+  mid: MIDI
+  midi: MIDI
+  m4a: MP4 오디오
+  mp3: MP3 오디오
+  oga: Ogg 오디오
+  opus: OPUS 오디오
+  wav: WAV 오디오
+  weba: WebM 오디오
+  # Document formats
+  csv: CSV 스프레드시트
+  doc: Word 문서
+  docx: Word 문서
+  odp: OpenDocument 프레젠테이션
+  ods: OpenDocument 스프레드시트
+  odt: OpenDocument 텍스트
+  pdf: PDF 문서
+  ppt: PowerPoint 프레젠테이션
+  pptx: PowerPoint 프레젠테이션
+  rtf: 서식 있는 텍스트 문서
+  xls: Excel 스프레드시트
+  xlsx: Excel 스프레드시트
+  # Text formats
+  html: HTML 텍스트
+  js: JavaScript
+  json: JSON 텍스트
+  md: Markdown 텍스트
+  toml: TOML 텍스트
+  yaml: YAML 텍스트
+  yml: YAML 텍스트
+
+# ==============================================================================
+# File Size Units
+# ==============================================================================
+# Labels for file size units used in formatted file sizes.
+
+file_size_units:
+  # {$size} is the formatted numeric size for the current unit
+  b: '{$size} 바이트'
+  kb: '{$size} KB'
+  mb: '{$size} MB'
+  gb: '{$size} GB'
+  tb: '{$size} TB'

--- a/src/lib/locales/ko.yaml
+++ b/src/lib/locales/ko.yaml
@@ -1269,7 +1269,7 @@ boolean:
 
 cloud_storage:
   # Configuration error
-  invalid: 서비스가 올바르게 설정되지 않았습니다.
+  invalid: 서비스가 올바르게 구성되지 않았습니다.
 
   # Authentication states
   auth:

--- a/src/lib/locales/ko.yaml
+++ b/src/lib/locales/ko.yaml
@@ -1269,7 +1269,7 @@ boolean:
 
 cloud_storage:
   # Configuration error
-  invalid: 서비스가 올바르게 구성되지 않았습니다.
+  invalid: 서비스 설정이 올바르지 않습니다.
 
   # Authentication states
   auth:

--- a/src/lib/locales/ko.yaml
+++ b/src/lib/locales/ko.yaml
@@ -588,8 +588,8 @@ drop_files_here: |
 # File type validation errors
 unsupported_file_type: 지원되지 않는 파일 형식
 # {$type} is the expected asset type label, such as image or document
-dropped_file_type_mismatch: '놓으신 파일이 다음 형식 중 하나가 아닙니다: {$types}. 다시 시도하십시오.'
-dropped_image_type_mismatch: '놓으신 파일은 지원되지 않습니다. 다음 형식의 이미지만 사용할 수 있습니다: {$types}. 다시 시도하십시오.'
+dropped_file_type_mismatch: '드롭한 파일이 다음 형식 중 하나가 아닙니다: {$types}. 다시 시도하십시오.'
+dropped_image_type_mismatch: '드롭한 파일은 지원되지 않습니다. 다음 형식의 이미지만 사용할 수 있습니다: {$types}. 다시 시도하십시오.'
 
 # File chooser button label
 # {$count} is the number of files the picker allows the user to choose

--- a/src/lib/locales/ko.yaml
+++ b/src/lib/locales/ko.yaml
@@ -219,7 +219,7 @@ install_as_app: 앱으로 설치
 # Main page titles in the global navigation and page switcher button group
 contents: 콘텐츠
 assets: 에셋
-editorial_workflow: 편집 워크플로
+editorial_workflow: 에디토리얼 워크플로우
 cms_config: CMS 설정
 # Mobile menu page title (shown only on small screens)
 menu: 메뉴
@@ -454,7 +454,7 @@ creating_entries_disabled_by_quota: 이 컬렉션은 엔트리 {$quota}개 한�
 creating_entries_nearing_quota: |
   .input {$remaining :integer}
   .match $remaining
-    *   {{ 이 컬렉션이 엔트리 {$quota}개 한도에 근접했습니다. 엔트리를 {$remaining}개만 더 만들 수 있습니다. }}
+    *   {{ 이 컬렉션이 엔트리 {$quota}개 한도에 근접했습니다. 만들 수 있는 엔트리가 {$remaining}개 남았습니다. }}
 
 # Navigation: back links and list labels
 back_to_collection: 컬렉션으로 돌아가기
@@ -1432,7 +1432,7 @@ config:
   # Warning messages (logged to console)
   warning:
     oauth_no_app_id: OAuth 애플리케이션 ID가 정의되지 않았습니다. 사용자는 로그인하려면 액세스 토큰을 제공해야 합니다.
-    editorial_workflow_unsupported: 편집 워크플로는 Sveltia CMS에서 아직 지원되지 않습니다.
+    editorial_workflow_unsupported: 에디토리얼 워크플로우는 Sveltia CMS에서 아직 지원되지 않습니다.
     open_authoring_unsupported: 오픈 오소링은 Sveltia CMS에서 아직 지원되지 않습니다.
     nested_collections_unsupported: 중첩 컬렉션은 Sveltia CMS에서 아직 지원되지 않습니다.
     # {$prop} is the unsupported option name that will be ignored


### PR DESCRIPTION
Adds a Korean (`ko`) UI translation. Refs #891.

~Draft for now — I'm still reviewing the wording. The file itself is verified: key and comment parity with `en-US.yaml`, all 673 messages compile as MF2, build and tests pass.~

✅ Ready for Review
- [x] `ko.yaml`
- [x] Translations for  `Sveltia UI strings`

Notes:

The Korean translation uses a formal, polite register (하십시오체), with technical terms either kept in their commonly used Korean forms or transliterated where appropriate. I drafted it with AI assistance and reviewed it carefully, following the localization conventions commonly seen in developer documentation and cloud consoles such as Azure and AWS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)