### PR TITLE
fix(l10n): align preposition in locale_load_failed for Catalan (ca)

### DIFF
--- a/src/lib/locales/ca.yaml
+++ b/src/lib/locales/ca.yaml
@@ -241,7 +241,7 @@ change_language: Canvia la llengua
 # Toast notification shown while the translation for the selected language is being downloaded
 # {$locale} is the localized language name, e.g., “French”
 switching_language: S’està canviant a {$locale}…
-locale_load_failed: No s’ha pogut carregar la traducció al {$locale}. Torneu-ho a provar més tard.
+locale_load_failed: No s’ha pogut carregar la traducció en {$locale}. Torneu-ho a provar més tard.
 
 # Site and page navigation
 # Toolbar button aria-label for visiting the live site


### PR DESCRIPTION
Fixes a minor inconsistency in the Catalan localization: `locale_load_failed` used `al {$locale}` while all other strings containing `{$locale}` use `en {$locale}`.

**Change:**
```
- locale_load_failed: No s'ha pogut carregar la traducció al {$locale}. Torneu-ho a provar més tard.
+ locale_load_failed: No s'ha pogut carregar la traducció en {$locale}. Torneu-ho a provar més tard.
```

Closes #866